### PR TITLE
docs: add a quick project overview section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@
 
 ---
 
+## 项目速览（给初次接触的同学）
+
+- **定位**：这是一个 iOS 端风控 SDK（`CloudPhoneRiskKit`）与示例应用（`RiskDetectorApp`）的组合仓库，重点做端侧环境风险识别。
+- **核心能力域**：越狱/Hook/注入检测、行为信号分析、设备一致性校验、服务端聚合信号融合。
+- **代码结构（高频目录）**：
+  - `RiskDetectorApp/Sources/CloudPhoneRiskKit/`：SDK 主体（检测、决策、存储、上报、安全加固）。
+  - `RiskDetectorApp/Sources/CloudPhoneRiskAppCore/`：应用层编排（配置加载、检测流程、报告摘要）。
+  - `RiskDetectorApp/App/`：SwiftUI 示例 App（Dashboard、配置、结果展示、历史页）。
+  - `RiskDetectorApp/Tests/CloudPhoneRiskKitTests/`：核心单元测试（决策树、策略、评分、信号模型）。
+- **本地运行（SPM）**：在仓库根目录执行 `cd RiskDetectorApp && swift test` 可先验证核心逻辑测试。
+
 ## 版本演进
 
 | 版本 | 定位 | 关键能力 |


### PR DESCRIPTION
### Motivation
- 提供一个面向首次接触者的简要“项目速览”，帮助快速理解仓库定位、核心能力和本地验证入口。

### Description
- 在 `README.md` 顶部新增 `## 项目速览（给初次接触的同学）` 小节，概述仓库定位、核心能力域、主要目录（`RiskDetectorApp/Sources/CloudPhoneRiskKit/`、`RiskDetectorApp/Sources/CloudPhoneRiskAppCore/`、`RiskDetectorApp/App/`、`RiskDetectorApp/Tests/CloudPhoneRiskKitTests/`）并加入本地运行提示 `cd RiskDetectorApp && swift test`。

### Testing
- 运行 `cd RiskDetectorApp && swift test` 导致构建失败并报错 `no such module 'CryptoKit'`，该错误为当前 Linux 容器的工具链/平台限制，与本次文档改动无关。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee1703594832db43e717d7da6b570)