### PR TITLE
fix: deadlock in DeviceHistory.cleanup() calling persistIfDirty() und…

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
@@ -343,7 +343,7 @@ public final class DeviceHistory {
 
         if before != after {
             isDirty = true
-            persistIfDirty()
+            persistIfDirtyLocked()
         }
     }
 
@@ -450,7 +450,11 @@ public final class DeviceHistory {
     private func persistIfDirty() {
         lock.lock()
         defer { lock.unlock() }
+        persistIfDirtyLocked()
+    }
 
+    /// Must be called with `lock` already held.
+    private func persistIfDirtyLocked() {
         guard isDirty else { return }
         persistToDiskLocked(resetAnchor: false)
         isDirty = false


### PR DESCRIPTION
…er lock

cleanup() acquires NSLock then calls persistIfDirty(), which tries to acquire the same non-reentrant lock — guaranteed deadlock on any cleanup call that actually removes snapshots.

Fix: extract persistIfDirtyLocked() (no lock inside) and call it from cleanup() which already holds the lock. The public persistIfDirty() path (used by the async dispatch in addSnapshot) retains its own lock acquire.

https://claude.ai/code/session_01V4fDXxFW2hb3EhwX6yb9eP