### PR TITLE
fix: two correctness bugs in SDK 4.6 modules

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/HoneypotMemoryDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/HoneypotMemoryDetector.swift
@@ -206,8 +206,8 @@ struct HoneypotMemoryDetector: Detector {
         var regionSize: vm_size_t = 0
         var info = vm_region_basic_info_data_64_t()
         var count = mach_msg_type_number_t(
-            MemoryLayout<vm_region_basic_info_data_64_t>.size
-                / MemoryLayout<natural_t>.size
+            MemoryLayout<vm_region_basic_info_data_64_t>.stride
+                / MemoryLayout<natural_t>.stride
         )
         var objectName: mach_port_t = 0
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
@@ -304,13 +304,12 @@ public enum CallStackUnwinder {
             return AddressValidation(legitimate: true, dladdrHooked: false)
         }
 
-        // Layer 5: vm_region cross-validation for unknown/suspicious paths
+        // Layer 5: vm_region cross-validation for unknown/suspicious paths.
+        // fileMapped  → address backed by a file on disk (legitimate late-loaded framework)
+        // anonymousExecutable → shellcode / ROP gadget page (malicious)
+        // unknown     → vm_region failed or ambiguous → treat as suspect
         let vmClass = vmRegionClassify(addr)
-        if vmClass == .anonymousExecutable {
-            return AddressValidation(legitimate: false, dladdrHooked: false)
-        }
-
-        return AddressValidation(legitimate: false, dladdrHooked: false)
+        return AddressValidation(legitimate: vmClass == .fileMapped, dladdrHooked: false)
     }
 
     // MARK: - vm_region_64 cross-validation


### PR DESCRIPTION
CallStackUnwinder (validateAddress Layer 5):
- Final vm_region cross-validation had dead code: both the anonymousExecutable branch and the fallthrough returned legitimate: false, making the if-check a no-op.
- fileMapped addresses (legitimate late-loaded frameworks) were incorrectly flagged as ROP chain entries → false positives.
- Fix: return legitimate: true for fileMapped, false for anonymousExecutable/unknown, collapsing the two returns into one.

HoneypotMemoryDetector (isPageProtNone):
- count for vm_region_64 was computed with .size / .size. vm_region_basic_info_data_64_t contains a uint64 field causing trailing alignment padding (size ≠ stride); .size underestimates the count, matching C's VM_REGION_BASIC_INFO_COUNT_64 incorrectly.
- Fix: use .stride / .stride, which equals C sizeof() and matches the constant the kernel expects