### PR TITLE
fix: isAdrpOrLdrLiteral ADRP destination register not checked (SDK 4.7)

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
@@ -98,7 +98,15 @@ enum LibcPrologueGuard {
     }
 
     private static func isAdrpOrLdrLiteral(_ insn: UInt32) -> Bool {
-        if insn & 0x9F00_0000 == 0x9000_0000 { return true }
+        // ADRP: only flag when destination is x16 (IP0) or x17 (IP1).
+        // The caller pairs this with isBranchRegister (BR x16/x17), so the
+        // destination must match the branch register to form a valid trampoline.
+        // Accepting any ADRP destination caused false positives when normal code
+        // happened to have ADRP Xn + BR x16/x17 with n ≠ 16/17.
+        if insn & 0x9F00_0000 == 0x9000_0000 {
+            let rd = insn & 0x1F
+            return rd == 0x10 || rd == 0x11
+        }
         if insn & 0xFF00_0000 == 0x5800_0000 {
             let rd = insn & 0x1F
             if rd == 0x10 || rd == 0x11 { return true }


### PR DESCRIPTION
The two-instruction hook pattern check in isInlineHooked:
    isAdrpOrLdrLiteral(insn0) && isBranchRegister(insn1)
pairs ADRP/LDR with BR x16 or BR x17. isBranchRegister correctly limits to x16/x17, but isAdrpOrLdrLiteral accepted ANY ADRP destination.

Result: ADRP x0, #page + BR x16 (completely normal code where x16 was set earlier) was incorrectly flagged as a hook trampoline.

A valid inline-hook trampoline must load the target address into the same register that is later branched to (e.g. ADRP x16 + BR x16). Restrict the ADRP arm of isAdrpOrLdrLiteral to rd == x16 (0x10) or rd == x17 (0x11), matching the same constraint already applied to the LDR-literal arm.

