### PR TITLE
fix: data race in LibcPrologueGuard.checkAllCritical (SDK 4.8)

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
@@ -35,18 +35,20 @@ enum LibcPrologueGuard {
     private static let rescanProbabilityPercent = 30
 
     static func checkAllCritical() -> Bool {
-        let shouldRescan = arc4random_uniform(100) < UInt32(rescanProbabilityPercent)
-        if shouldRescan || lastScannedResult == nil {
+        // Read lastScannedResult under lock to avoid data race with concurrent writers.
+        lock.lock()
+        let current = lastScannedResult
+        lock.unlock()
+
+        let shouldRescan = current == nil || arc4random_uniform(100) < UInt32(rescanProbabilityPercent)
+        if shouldRescan {
             let result = performFullScan()
             lock.lock()
             lastScannedResult = result
             lock.unlock()
             return result
         }
-        lock.lock()
-        let cached = lastScannedResult ?? false
-        lock.unlock()
-        return cached
+        return current!  // Safe: current != nil when shouldRescan is false
     }
 
     private static func performFullScan() -> Bool {


### PR DESCRIPTION
lastScannedResult is a mutable var guarded by an NSLock, but the nil-check on line 39 was performed outside the lock:

    if shouldRescan || lastScannedResult == nil {  // unsynchronised read

While the write (lines 41-43) was always under the lock. Concurrent calls could race on the read, causing Swift undefined behavior.

Fix: read lastScannedResult under the lock into a local `current`, then decide outside whether to rescan. The benign TOCTOU (read then write without holding lock continuously) is acceptable since performFullScan() is idempotent — at worst two threads both scan once. Also simplify the control flow: merge both branches into one rescan path and one cached-