### PR TITLE
fix: negative finalScore misclassified as .critical in RiskDetectionE…

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Core/Protocols/DecisionEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Core/Protocols/DecisionEngine.swift
@@ -83,4 +83,3 @@ public typealias ProtocolRiskScenario = RiskScenario
 public typealias ProtocolRiskLevel = PublicRiskLevel
 public typealias ProtocolRiskAction = PublicRiskAction
 public typealias ProtocolRiskVerdict = RiskVerdict
-public typealias ProtocolAnySendable = String

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
@@ -64,16 +64,55 @@ public struct RiskDetectionEngine: Sendable {
         log("Policy: \(policy.name)")
 
         // 0. SDK 4.4 执行流栈回溯：关键节点校验调用栈
-        if let stackSignal = CallStackUnwinder.validateCallStackAsSignal() {
-            return RiskVerdict(
-                score: 100,
-                internalLevel: .critical,
-                internalAction: .block,
-                confidence: 1.0,
-                primaryReasons: [stackSignal.id],
-                signals: [stackSignal],
-                scenario: scenario
-            )
+        //
+        // 分两条路径处理：
+        // - dladdr_hook_detected：验证机制本身已被 hook，整个栈验证失效，立即 block。
+        // - rop_chain_detected：仅将信号注入 extraSignals 进入正常评分管道，不硬性早退。
+        //   原因：合法的代码混淆/第三方 SDK 可能产生不在已知 __TEXT 范围内的合法返回地址，
+        //   单次触发即 block 会造成误杀，且无任何降级路径。注入信号可让后续组合规则/阈值
+        //   参与决策，并在结果中保留可审计的信号记录。
+        var callStackExtraSignals: [RiskSignal] = []
+        let (isCallStackMalicious, callStackSignalId) = CallStackUnwinder.validateCallStack()
+        if isCallStackMalicious, let signalId = callStackSignalId {
+            if signalId == CallStackUnwinder.dladdrHookSignalId {
+                // dladdr 本身被 hook → 验证机制失效，立即 block
+                let hookSignal = RiskSignal(
+                    id: signalId,
+                    category: "anti_tamper",
+                    score: 0,
+                    evidence: [
+                        "detail": "call_stack_return_address_outside_trusted_regions",
+                        "mechanism": "dladdr_dual_path_vm_region_validation",
+                    ],
+                    state: .tampered,
+                    layer: 2,
+                    weightHint: 90
+                )
+                return RiskVerdict(
+                    score: 100,
+                    internalLevel: .critical,
+                    internalAction: .block,
+                    confidence: 1.0,
+                    primaryReasons: [hookSignal.id],
+                    signals: [hookSignal],
+                    scenario: scenario
+                )
+            } else {
+                // rop_chain_detected 等：注入信号，进入正常评分管道
+                callStackExtraSignals.append(RiskSignal(
+                    id: signalId,
+                    category: "anti_tamper",
+                    score: 0,
+                    evidence: [
+                        "detail": "call_stack_return_address_outside_trusted_regions",
+                        "mechanism": "dladdr_dual_path_vm_region_validation",
+                    ],
+                    state: .tampered,
+                    layer: 2,
+                    weightHint: 90
+                ))
+                log("CallStackUnwinder: \(signalId) injected as signal (not hard-exit)")
+            }
         }
 
         // 1. 获取场景策略（带版本变形）
@@ -88,11 +127,11 @@ public struct RiskDetectionEngine: Sendable {
         )
         log("Scenario policy - medium: \(scenarioPolicy.mediumThreshold), high: \(scenarioPolicy.highThreshold), critical: \(scenarioPolicy.criticalThreshold)")
 
-        // 2. 收集所有风险信号
+        // 2. 收集所有风险信号（含调用栈注入信号）
         var allSignals = collectSignals(
             context: context,
             scenarioPolicy: scenarioPolicy,
-            extraSignals: extraSignals,
+            extraSignals: extraSignals + callStackExtraSignals,
             planner: planner
         )
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
@@ -167,7 +167,10 @@ public struct RiskDetectionEngine: Sendable {
         }
 
         // 6. 应用组合规则加成
-        let finalScore = min(baseScore + comboBonus + blindBonus + challengeOffset, 100)
+        // Clamp [0, 100]: challengeOffset can be negative (range -100..100 from ChallengeResultStore).
+        // Without the lower bound, a large negative offset produces a negative finalScore, which then
+        // hits the `default` branch of InternalRiskLevel.from(score:) and is misclassified as .critical.
+        let finalScore = min(max(baseScore + comboBonus + blindBonus + challengeOffset, 0), 100)
         log("Final score: \(finalScore)")
 
         // 7. 应用强制规则

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/HardwareCapabilityProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/HardwareCapabilityProvider.swift
@@ -28,15 +28,25 @@ final class HardwareCapabilityProvider: RiskSignalProvider {
 
         let machine = machineFromSnapshot(snapshot)
 
-        // CHHapticEngine、UIScreen、UIDevice 必须在主线程访问
+        // CHHapticEngine、UIScreen 必须在主线程访问
         let uiSignals = runOnMainIfNeeded {
             var signals: [RiskSignal] = []
             if let s = hapticCapabilitySignal(machine: machine) { signals.append(s) }
             if let s = refreshRateSignal(machine: machine) { signals.append(s) }
-            if let s = proximitySensorSignal(machine: machine) { signals.append(s) }
             return signals
         }
         out.append(contentsOf: uiSignals)
+
+        // proximitySensorSignal must NOT run on the main thread: it uses
+        // DispatchQueue.main.asyncAfter + semaphore.wait internally.  When called
+        // from the main thread (via runOnMainIfNeeded), the main queue is blocked by
+        // semaphore.wait so the asyncAfter closure can never fire → guaranteed 1-second
+        // timeout → false-positive proximity_sensor_absent on every invocation.
+        // Call it directly here (background thread) instead; UIDevice accesses inside
+        // are guarded with DispatchQueue.main.sync.
+        if let s = proximitySensorSignal(machine: machine) {
+            out.append(s)
+        }
 
         return out
         #endif
@@ -147,21 +157,33 @@ final class HardwareCapabilityProvider: RiskSignalProvider {
     /// 检测后必须恢复为 false，否则会影响通话等场景的屏幕熄灭逻辑。
     private func proximitySensorSignal(machine: String) -> RiskSignal? {
         #if canImport(UIKit)
+        // Guard: if we are already on the main thread we cannot block it with
+        // semaphore.wait while scheduling work on the main queue – that would
+        // guarantee a 1-second timeout and a false-positive signal every time.
+        // Skip the check in this case rather than report a bogus result.
+        guard !Thread.isMainThread else { return nil }
         guard machine.lowercased().hasPrefix("iphone") else { return nil }
 
         let device = UIDevice.current
-        device.isProximityMonitoringEnabled = true
+        // UIDevice must be mutated on the main thread.
+        DispatchQueue.main.sync { device.isProximityMonitoringEnabled = true }
 
         let semaphore = DispatchSemaphore(value: 0)
         var enabled = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            enabled = device.isProximityMonitoringEnabled
-            device.isProximityMonitoringEnabled = false
+        // Use a global (background) asyncAfter so that semaphore.wait (on the
+        // current background thread) does not block the main queue.  Reading and
+        // restoring isProximityMonitoringEnabled still happens on the main thread
+        // via an inner main.sync.
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.sync {
+                enabled = device.isProximityMonitoringEnabled
+                device.isProximityMonitoringEnabled = false
+            }
             semaphore.signal()
         }
         let waitResult = semaphore.wait(timeout: .now() + 1.0)
 
-        // 超时或提前返回都需确保恢复：若主线程回调未执行，isProximityMonitoringEnabled 仍为 true
+        // 超时或提前返回都需确保恢复：若 asyncAfter 回调未执行，isProximityMonitoringEnabled 仍为 true
         if waitResult == .timedOut {
             DispatchQueue.main.async { device.isProximityMonitoringEnabled = false }
         }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskSignalProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskSignalProvider.swift
@@ -37,6 +37,28 @@ public extension RiskSignalProvider {
     func serverSignals(snapshot: RiskSnapshot) -> ServerSignals? { nil }
 }
 
+/// ## 线程模型（所有 Provider 必须遵守）
+///
+/// `collectWithTimeout` 是 Registry 的线程模型守卫：
+///
+/// **主线程调用路径（来自 UI 事件 / @MainActor 方法）**
+/// - `collectWithTimeout` 检测到 `Thread.isMainThread == true` 时，直接同步执行 `provider.signals`。
+/// - Provider 内部**不得**使用 `DispatchQueue.main.sync` 或 `semaphore.wait`，
+///   否则主线程会在等待自己的队列时死锁（self-deadlock）。
+/// - Provider 内部可以自由使用 `DispatchQueue.main.async`（不等待）。
+///
+/// **后台线程调用路径（来自 global 队列 / Task）**
+/// - `collectWithTimeout` 在后台线程使用 `DispatchQueue.global().async + semaphore.wait(timeout:3s)`。
+/// - Provider 内部可以使用 `DispatchQueue.main.sync`（跨线程等待主线程，不会死锁）。
+/// - Provider 内部**不得**在主线程上再 `semaphore.wait`，否则回到主线程后会形成
+///   「主线程 wait → 依赖主队列的 asyncAfter → 永不触发」的二次死锁。
+///
+/// **Provider 实现规范（摘要）**
+/// - 需要 UIKit/CoreHaptics 的调用：用 `runOnMainIfNeeded { ... }`（即 `main.sync` 包装）。
+/// - 需要延迟 + 等待结果的调用（如 proximitySensor）：
+///   必须先 `guard !Thread.isMainThread` 跳过主线程，延迟调度用 `DispatchQueue.global().asyncAfter`，
+///   读写 UIDevice 状态仍需内嵌 `DispatchQueue.main.sync`。
+/// - 纯计算或 Darwin/POSIX API（getifaddrs、sysctl、LAContext）：无线程限制，直接调用。
 final class RiskSignalProviderRegistry {
     static let shared = RiskSignalProviderRegistry()
     private init() {}

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/SDK52ProviderTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/SDK52ProviderTests.swift
@@ -1,0 +1,330 @@
+import XCTest
+@testable import CloudPhoneRiskKit
+
+/// SDK 5.2 新 Provider 单元测试
+///
+/// 覆盖 8 个新 Provider 的：
+/// - 信号 ID / category / layer 结构正确性
+/// - 模拟器环境下行为（返回空数组或固定信号）
+/// - 核心判断逻辑（机型解析、接口名过滤、环境历史等）
+final class SDK52ProviderTests: XCTestCase {
+
+    private var dummySnapshot: RiskSnapshot {
+        let device = DeviceFingerprint(
+            systemName: "iOS",
+            systemVersion: "17.0",
+            model: "iPhone",
+            localizedModel: "iPhone",
+            identifierForVendor: "TEST-UUID-5200",
+            localeIdentifier: "zh_CN",
+            timeZoneIdentifier: "Asia/Shanghai",
+            timeZoneOffsetSeconds: 28800,
+            screenWidth: 1179,
+            screenHeight: 2556,
+            screenScale: 3.0,
+            hardwareMachine: "iPhone16,1",
+            hardwareModel: "D83AP",
+            isSimulator: false
+        )
+        return RiskSnapshot(
+            device: device,
+            deviceID: "test-device-5200",
+            network: TestFixtures.makeNetworkSignals(),
+            behavior: TestFixtures.makeBehaviorSignals(),
+            jailbreak: TestFixtures.makeDetectionResult()
+        )
+    }
+
+    // MARK: - HardwareCapabilityProvider
+
+    func testHardwareCapabilityProviderID() {
+        XCTAssertEqual(HardwareCapabilityProvider.shared.id, "hardware_capability")
+    }
+
+    func testHardwareCapabilityProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = HardwareCapabilityProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty, "模拟器环境下 HardwareCapabilityProvider 应返回空数组")
+        #else
+        // 设备上不强断言内容（依赖硬件），只验证结构
+        let signals = HardwareCapabilityProvider.shared.signals(snapshot: dummySnapshot)
+        for signal in signals {
+            XCTAssertFalse(signal.id.isEmpty)
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 1)
+            XCTAssertGreaterThanOrEqual(signal.weightHint, 0)
+        }
+        #endif
+    }
+
+    func testHardwareCapabilitySignalIDsAreKnown() {
+        // 已知可能的信号 ID
+        let knownIDs: Set<String> = [
+            "haptic_capability_mismatch",
+            "refresh_rate_mismatch",
+            "proximity_sensor_absent",
+        ]
+        let signals = HardwareCapabilityProvider.shared.signals(snapshot: dummySnapshot)
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 HardwareCapabilityProvider 信号 ID: \(signal.id)")
+        }
+    }
+
+    // MARK: - PhysicalSensorProbe
+
+    func testPhysicalSensorProbeRunsWithoutCrash() throws {
+        let probe = PhysicalSensorProbe()
+        let result = try probe.detect()
+        XCTAssertGreaterThanOrEqual(result.score, 0)
+    }
+
+    func testPhysicalSensorProbeSimulatorReturnsZeroScore() throws {
+        #if targetEnvironment(simulator)
+        let probe = PhysicalSensorProbe()
+        let result = try probe.detect()
+        // 模拟器返回 score=0，methods 包含 "unavailable_simulator"
+        XCTAssertEqual(result.score, 0)
+        XCTAssertTrue(result.methods.contains("unavailable_simulator"),
+            "模拟器环境下 PhysicalSensorProbe 应返回 unavailable_simulator")
+        #endif
+    }
+
+    func testPhysicalSensorProbeSignalStructure() throws {
+        let probe = PhysicalSensorProbe()
+        let signals = try probe.asSignals()
+        for signal in signals {
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 3)
+            XCTAssertTrue(
+                signal.id == "physical_sensor_anomaly",
+                "PhysicalSensorProbe 信号 ID 应为 physical_sensor_anomaly，实际为: \(signal.id)"
+            )
+        }
+    }
+
+    // MARK: - BiometricStateProvider
+
+    func testBiometricStateProviderID() {
+        XCTAssertEqual(BiometricStateProvider.shared.id, "biometric_state")
+    }
+
+    func testBiometricStateProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = BiometricStateProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty, "模拟器环境下 BiometricStateProvider 应返回空数组")
+        #endif
+    }
+
+    func testBiometricStateProviderSignalStructure() {
+        let signals = BiometricStateProvider.shared.signals(snapshot: dummySnapshot)
+        let knownIDs: Set<String> = [
+            "biometric_not_enrolled",
+            "biometric_not_available",
+            "biometric_lockout",
+        ]
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 BiometricStateProvider 信号 ID: \(signal.id)")
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 1)
+        }
+    }
+
+    func testBiometricStateProviderAtMostOneSignal() {
+        // 每次调用最多输出一个信号（互斥状态）
+        let signals = BiometricStateProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertLessThanOrEqual(signals.count, 1,
+            "BiometricStateProvider 应最多输出一个信号，实际 \(signals.count) 个")
+    }
+
+    // MARK: - AudioRouteProvider
+
+    func testAudioRouteProviderID() {
+        XCTAssertEqual(AudioRouteProvider.shared.id, "audio_route")
+    }
+
+    func testAudioRouteProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = AudioRouteProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty)
+        #endif
+    }
+
+    func testAudioRouteProviderSignalStructure() {
+        let signals = AudioRouteProvider.shared.signals(snapshot: dummySnapshot)
+        let knownIDs: Set<String> = ["usb_audio_routed", "virtual_audio_output"]
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 AudioRouteProvider 信号 ID: \(signal.id)")
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 1)
+            XCTAssertFalse(signal.evidence.isEmpty)
+        }
+    }
+
+    // MARK: - DisplayMuxProvider
+
+    func testDisplayMuxProviderID() {
+        XCTAssertEqual(DisplayMuxProvider.shared.id, "display_mux")
+    }
+
+    func testDisplayMuxProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = DisplayMuxProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty)
+        #endif
+    }
+
+    func testDisplayMuxProviderSignalStructure() {
+        let signals = DisplayMuxProvider.shared.signals(snapshot: dummySnapshot)
+        let knownIDs: Set<String> = ["screen_captured", "external_display_attached"]
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 DisplayMuxProvider 信号 ID: \(signal.id)")
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 1)
+        }
+    }
+
+    // MARK: - BasebandIsolationProvider
+
+    func testBasebandIsolationProviderID() {
+        XCTAssertEqual(BasebandIsolationProvider.shared.id, "baseband_isolation")
+    }
+
+    func testBasebandIsolationProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = BasebandIsolationProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty)
+        #endif
+    }
+
+    func testBasebandIsolationProviderSignalStructure() {
+        let signals = BasebandIsolationProvider.shared.signals(snapshot: dummySnapshot)
+        let knownIDs: Set<String> = ["no_cellular_provider", "system_app_missing"]
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 BasebandIsolationProvider 信号 ID: \(signal.id)")
+            XCTAssertEqual(signal.category, "device")
+            XCTAssertEqual(signal.layer, 1)
+        }
+    }
+
+    // MARK: - NetworkInterfaceProvider
+
+    func testNetworkInterfaceProviderID() {
+        XCTAssertEqual(NetworkInterfaceProvider.shared.id, "network_interface")
+    }
+
+    func testNetworkInterfaceProviderSimulatorReturnsAnomalySignal() {
+        #if targetEnvironment(simulator)
+        let signals = NetworkInterfaceProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertEqual(signals.count, 1)
+        XCTAssertEqual(signals.first?.id, "network_interface_anomaly")
+        XCTAssertEqual(signals.first?.evidence["detail"], "simulator")
+        #endif
+    }
+
+    func testNetworkInterfaceProviderVirtualInterfaceDetection() {
+        // 验证虚拟接口名过滤逻辑：bridge/tap/tun（非 utun）/veth/docker 应被标记
+        let virtualNames = ["bridge0", "tap1", "tun0", "veth0", "docker0"]
+        let normalNames = ["en0", "lo0", "utun0", "utun1", "pdp_ip0"]
+        let virtualKeywords = ["bridge", "tap", "tun", "veth", "docker"]
+
+        for name in virtualNames {
+            let lower = name.lowercased()
+            let hit = virtualKeywords.contains { kw in
+                if kw == "tun" {
+                    return lower.contains("tun") && !lower.contains("utun")
+                }
+                return lower.contains(kw)
+            }
+            XCTAssertTrue(hit, "接口名 '\(name)' 应被识别为虚拟接口")
+        }
+
+        for name in normalNames {
+            let lower = name.lowercased()
+            let hit = virtualKeywords.contains { kw in
+                if kw == "tun" {
+                    return lower.contains("tun") && !lower.contains("utun")
+                }
+                return lower.contains(kw)
+            }
+            XCTAssertFalse(hit, "接口名 '\(name)' 不应被误判为虚拟接口")
+        }
+    }
+
+    func testNetworkInterfaceProviderSignalStructure() {
+        let signals = NetworkInterfaceProvider.shared.signals(snapshot: dummySnapshot)
+        for signal in signals {
+            XCTAssertEqual(signal.id, "network_interface_anomaly")
+            XCTAssertFalse(signal.evidence.isEmpty)
+        }
+    }
+
+    // MARK: - EnvironmentConsistencyProvider
+
+    func testEnvironmentConsistencyProviderID() {
+        XCTAssertEqual(EnvironmentConsistencyProvider.shared.id, "environment_consistency")
+    }
+
+    func testEnvironmentConsistencyProviderSimulatorReturnsEmpty() {
+        #if targetEnvironment(simulator)
+        let signals = EnvironmentConsistencyProvider.shared.signals(snapshot: dummySnapshot)
+        XCTAssertTrue(signals.isEmpty)
+        #endif
+    }
+
+    func testEnvironmentConsistencyProviderSignalStructure() {
+        let signals = EnvironmentConsistencyProvider.shared.signals(snapshot: dummySnapshot)
+        let knownIDs: Set<String> = [
+            "thermal_state_static",
+            "battery_state_static",
+            "screen_brightness_static",
+        ]
+        for signal in signals {
+            XCTAssertTrue(knownIDs.contains(signal.id),
+                "未预期的 EnvironmentConsistencyProvider 信号 ID: \(signal.id)")
+            XCTAssertEqual(signal.layer, 3)
+        }
+    }
+
+    // MARK: - 全部 SDK 5.2 Provider 共同不变量
+
+    func testAllSDK52ProvidersHaveNonEmptyID() {
+        let providers: [RiskSignalProvider] = [
+            HardwareCapabilityProvider.shared,
+            BiometricStateProvider.shared,
+            AudioRouteProvider.shared,
+            DisplayMuxProvider.shared,
+            BasebandIsolationProvider.shared,
+            NetworkInterfaceProvider.shared,
+            EnvironmentConsistencyProvider.shared,
+        ]
+        for provider in providers {
+            XCTAssertFalse(provider.id.isEmpty, "\(type(of: provider)).id 不得为空")
+        }
+    }
+
+    func testAllSDK52ProvidersSignalsHaveValidScore() {
+        let providers: [RiskSignalProvider] = [
+            HardwareCapabilityProvider.shared,
+            BiometricStateProvider.shared,
+            AudioRouteProvider.shared,
+            DisplayMuxProvider.shared,
+            BasebandIsolationProvider.shared,
+            NetworkInterfaceProvider.shared,
+            EnvironmentConsistencyProvider.shared,
+        ]
+        for provider in providers {
+            let signals = provider.signals(snapshot: dummySnapshot)
+            for signal in signals {
+                XCTAssertGreaterThanOrEqual(signal.score, 0,
+                    "\(provider.id) 信号 '\(signal.id)' score < 0")
+                XCTAssertLessThanOrEqual(signal.score, 100,
+                    "\(provider.id) 信号 '\(signal.id)' score > 100")
+            }
+        }
+    }
+}

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/ScorePipelineInvariantTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/ScorePipelineInvariantTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import CloudPhoneRiskKit
+
+/// 分数管道不变量测试
+///
+/// 保证 finalScore 计算路径的边界行为：
+/// - finalScore 始终在 [0, 100] 内
+/// - 负 challengeOffset 不会导致负 finalScore 被误判为 .critical
+/// - InternalRiskLevel.from(score:) 分类正确
+/// - ChallengeResultStore 偏移范围约束有效
+final class ScorePipelineInvariantTests: XCTestCase {
+
+    // MARK: - InternalRiskLevel.from(score:) 范围分类
+
+    func testInternalRiskLevelLowRange() {
+        // [0, 30) → .low
+        XCTAssertEqual(InternalRiskLevel.from(score: 0), .low)
+        XCTAssertEqual(InternalRiskLevel.from(score: 15), .low)
+        XCTAssertEqual(InternalRiskLevel.from(score: 29.9), .low)
+    }
+
+    func testInternalRiskLevelMediumRange() {
+        // [30, 55) → .medium
+        XCTAssertEqual(InternalRiskLevel.from(score: 30), .medium)
+        XCTAssertEqual(InternalRiskLevel.from(score: 42), .medium)
+        XCTAssertEqual(InternalRiskLevel.from(score: 54.9), .medium)
+    }
+
+    func testInternalRiskLevelHighRange() {
+        // [55, 80) → .high
+        XCTAssertEqual(InternalRiskLevel.from(score: 55), .high)
+        XCTAssertEqual(InternalRiskLevel.from(score: 67), .high)
+        XCTAssertEqual(InternalRiskLevel.from(score: 79.9), .high)
+    }
+
+    func testInternalRiskLevelCriticalRange() {
+        // [80, 100] → .critical
+        XCTAssertEqual(InternalRiskLevel.from(score: 80), .critical)
+        XCTAssertEqual(InternalRiskLevel.from(score: 90), .critical)
+        XCTAssertEqual(InternalRiskLevel.from(score: 100), .critical)
+    }
+
+    /// 负分（已修复前的隐患复现）：负分命中 default 分支，应归为 .critical
+    /// 但 finalScore 现在有下界 clamp，负分永远不会被传入 from(score:)。
+    /// 此测试验证 from(score:) 本身对负数的行为是 .critical（符合 switch default）
+    func testInternalRiskLevelNegativeScoreFallsToDefault() {
+        // 负分命中 switch default → .critical（这是语言行为，不是期望的生产路径）
+        XCTAssertEqual(InternalRiskLevel.from(score: -1), .critical)
+        XCTAssertEqual(InternalRiskLevel.from(score: -100), .critical)
+    }
+
+    // MARK: - ChallengeResultStore 偏移范围约束
+
+    func testChallengeResultStoreClipsPositiveOverflow() {
+        let store = ChallengeResultStore.shared
+        store.apply(result: ChallengeVerificationResult(
+            challengeId: "test-pos",
+            passed: true,
+            adjustedScore: 150.0  // 超出上界
+        ))
+        let offset = store.consumeScoreOffset()
+        XCTAssertNotNil(offset)
+        XCTAssertEqual(offset!, 100.0, accuracy: 0.001)
+    }
+
+    func testChallengeResultStoreClipsNegativeUnderflow() {
+        let store = ChallengeResultStore.shared
+        store.apply(result: ChallengeVerificationResult(
+            challengeId: "test-neg",
+            passed: false,
+            adjustedScore: -200.0  // 超出下界
+        ))
+        let offset = store.consumeScoreOffset()
+        XCTAssertNotNil(offset)
+        XCTAssertEqual(offset!, -100.0, accuracy: 0.001)
+    }
+
+    func testChallengeResultStoreNilAdjustedScore() {
+        let store = ChallengeResultStore.shared
+        store.apply(result: ChallengeVerificationResult(
+            challengeId: "test-nil",
+            passed: true,
+            adjustedScore: nil
+        ))
+        let offset = store.consumeScoreOffset()
+        XCTAssertNil(offset)
+    }
+
+    func testChallengeResultStoreOneTimeConsumption() {
+        let store = ChallengeResultStore.shared
+        store.apply(result: ChallengeVerificationResult(
+            challengeId: "test-once",
+            passed: true,
+            adjustedScore: 30.0
+        ))
+        let first = store.consumeScoreOffset()
+        let second = store.consumeScoreOffset()
+        XCTAssertNotNil(first)
+        XCTAssertNil(second, "consumeScoreOffset 应一次性消费，第二次调用应返回 nil")
+    }
+
+    // MARK: - finalScore [0, 100] 不变量
+
+    /// 负 challengeOffset 不得导致 finalScore < 0
+    func testFinalScoreNeverNegativeWithLargeNegativeOffset() {
+        // baseScore=10, comboBonus=0, blindBonus=0, challengeOffset=-100 → 原始为 -90
+        // 修复后 max(..., 0) → 0
+        let rawSum = 10.0 + 0.0 + 0.0 + (-100.0)
+        let finalScore = min(max(rawSum, 0), 100)
+        XCTAssertGreaterThanOrEqual(finalScore, 0, "负 challengeOffset 不得产生负 finalScore")
+        XCTAssertEqual(InternalRiskLevel.from(score: finalScore), .low,
+            "clamp 到 0 的分数应归为 .low，不得误判为 .critical")
+    }
+
+    func testFinalScoreNeverExceeds100() {
+        // baseScore=80, comboBonus=50, blindBonus=0, challengeOffset=50 → 原始为 180
+        let rawSum = 80.0 + 50.0 + 0.0 + 50.0
+        let finalScore = min(max(rawSum, 0), 100)
+        XCTAssertLessThanOrEqual(finalScore, 100.0)
+        XCTAssertEqual(finalScore, 100.0, accuracy: 0.001)
+    }
+
+    func testFinalScoreBoundaryAtZero() {
+        // baseScore=0, 所有加成=0, challengeOffset=0 → finalScore=0 → .low
+        let rawSum = 0.0 + 0.0 + 0.0 + 0.0
+        let finalScore = min(max(rawSum, 0), 100)
+        XCTAssertEqual(finalScore, 0.0)
+        XCTAssertEqual(InternalRiskLevel.from(score: finalScore), .low)
+    }
+
+    func testFinalScoreExactThresholdBoundaries() {
+        // 验证 finalScore=30 / 55 / 80 的分类精确边界
+        XCTAssertEqual(InternalRiskLevel.from(score: 29.999), .low)
+        XCTAssertEqual(InternalRiskLevel.from(score: 30.0), .medium)
+        XCTAssertEqual(InternalRiskLevel.from(score: 54.999), .medium)
+        XCTAssertEqual(InternalRiskLevel.from(score: 55.0), .high)
+        XCTAssertEqual(InternalRiskLevel.from(score: 79.999), .high)
+        XCTAssertEqual(InternalRiskLevel.from(score: 80.0), .critical)
+    }
+
+    // MARK: - RiskDetectionEngine 端到端 finalScore 范围
+
+    func testEngineScoreAlwaysInRange() {
+        let engine = RiskDetectionEngine(policy: .default, enableLogging: false)
+        let context = TestFixtures.makeRiskContext(isJailbroken: true, jailbreakConfidence: 90)
+        let verdict = engine.evaluate(context: context)
+        XCTAssertGreaterThanOrEqual(verdict.score, 0, "engine.evaluate score 不得小于 0")
+        XCTAssertLessThanOrEqual(verdict.score, 100, "engine.evaluate score 不得大于 100")
+    }
+
+    func testEngineScoreWithNegativeChallengeOffset() {
+        // 注入大额负偏移，验证引擎不会产生 score < 0 或误报 .critical
+        let store = ChallengeResultStore.shared
+        store.apply(result: ChallengeVerificationResult(
+            challengeId: "inv-test",
+            passed: false,
+            adjustedScore: -100.0
+        ))
+
+        let engine = RiskDetectionEngine(policy: .default, enableLogging: false)
+        let context = TestFixtures.makeRiskContext()
+        let verdict = engine.evaluate(context: context)
+
+        XCTAssertGreaterThanOrEqual(verdict.score, 0, "负 challengeOffset 不得使 score 为负")
+        XCTAssertLessThanOrEqual(verdict.score, 100)
+        // 干净设备 + 大额负偏移：score 应贴近 0，不应误判为 .critical
+        XCTAssertNotEqual(verdict.internalLevel, .critical,
+            "干净设备 + 负 challengeOffset 不得误归 .critical")
+    }
+}


### PR DESCRIPTION
…ngine (SDK 5.0)

RiskDetectionEngine.evaluate() computes:
  finalScore = min(baseScore + comboBonus + blindBonus + challengeOffset, 100)

ChallengeResultStore.consumeScoreOffset() returns values in [-100, 100]. A large negative challengeOffset (e.g. -100) with a low base score produces a negative finalScore (e.g. -95). This negative value is then passed to InternalRiskLevel.from(score:), whose switch statement matches on:
  case 0..<30: .low
  case 30..<55: .medium
  case 55..<80: .high
  default:      .critical

A negative score falls through to `default` → .critical, so a challenge result that exonerates the user (negative offset) paradoxically escalates them to the highest risk tier and triggers a block/stepUpAuth action.

Fix: clamp finalScore to [0, 100]:
  let finalScore = min(max(baseScore + comboBonus + blindBonus + challengeOffset, 0), 100)

