### PR TITLE
fix: 修复评估管道四处静默 bug（SDK 5.2 后续）

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
@@ -586,7 +586,11 @@ public struct RiskDetectionEngine: Sendable {
         let minWeight = Self.criticalSignalMinWeights[signal.id] ?? 0
         let baseWeight: Double
         if signal.weightHint > 0 {
-            baseWeight = signal.weightHint
+            // minWeight must be enforced even when weightHint is explicitly set.
+            // Without max(), a critical signal whose weightHint is set to a low value
+            // (e.g. by a compromised/forged provider signal) would silently bypass
+            // its guaranteed floor, letting it contribute near-zero to the score.
+            baseWeight = max(signal.weightHint, minWeight)
             return planner.jitter(base: baseWeight, maxBps: policy.mutationStrategy?.scoreJitterBps ?? 0)
         }
         if let override = overrides[signal.id], override > 0 {
@@ -705,7 +709,10 @@ public struct RiskDetectionEngine: Sendable {
     private func minScore(for action: RiskAction, scenarioPolicy: ScenarioPolicy) -> Double {
         switch action {
         case .allow:
-            return scenarioPolicy.mediumThreshold
+            // Forcing .allow should NOT elevate the score. Returning mediumThreshold would
+            // produce a contradiction: action=allow but internalLevel=.medium, and would
+            // silently inflate the score when a blocklist/comboRule uses .allow as its action.
+            return 0
         case .challenge:
             return scenarioPolicy.highThreshold
         case .stepUpAuth, .block:
@@ -745,9 +752,14 @@ public struct RiskDetectionEngine: Sendable {
     }
 
     /// 提取主要原因
+    ///
+    /// Sort key 使用 `max(score, weightHint)`，而非单纯的 `.score`。
+    /// 原因：状态驱动信号（.tampered/.hard）统一将 score 设为 0，
+    /// 实际权重由 weightHint 表达。若仅按 score 排序，这些高危信号会被
+    /// 行为信号（score=10/8/5）压到末尾，导致主要原因与实际评分依据脱节。
     private func extractPrimaryReasons(signals: [RiskSignal]) -> [String] {
         signals
-            .sorted { $0.score > $1.score }
+            .sorted { max($0.score, $0.weightHint) > max($1.score, $1.weightHint) }
             .prefix(5)
             .map { signal in
                 var reason = signal.category

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskVerdict.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskVerdict.swift
@@ -122,10 +122,13 @@ public struct RiskVerdict: Codable, Sendable {
     // MARK: - 辅助方法
 
     /// 提取主要原因
+    ///
+    /// Sort key 使用 `max(score, weightHint)`，而非单纯的 `.score`。
+    /// 状态驱动信号（.tampered/.hard）score=0 而 weightHint 承载实际权重，
+    /// 若仅按 score 排序会将这些高危信号排到末尾，导致审计记录与真实原因脱节。
     private static func extractPrimaryReasons(signals: [RiskSignal], score: Double) -> [String] {
-        // 按分数降序排序，取前3个主要原因
         signals
-            .sorted { $0.score > $1.score }
+            .sorted { max($0.score, $0.weightHint) > max($1.score, $1.weightHint) }
             .prefix(3)
             .map { "\($0.category)_\($0.id)" }
     }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
@@ -286,13 +286,13 @@ public enum CallStackUnwinder {
         let found = nextFound
 
         // dladdr could not resolve → cross-validate with vm_region
-        if found == 0 || info.dli_fname == nil {
+        guard found != 0, let fname = info.dli_fname else {
             let vmClass = vmRegionClassify(addr)
             let legitimate = vmClass == .fileMapped
             return AddressValidation(legitimate: legitimate, dladdrHooked: false)
         }
 
-        let path = String(cString: info.dli_fname!)
+        let path = String(cString: fname)
 
         // Layer 3: trusted image cache (built from startup snapshot)
         if trustedImagePaths.contains(path) {

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/ScorePipelineInvariantTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/ScorePipelineInvariantTests.swift
@@ -167,4 +167,118 @@ final class ScorePipelineInvariantTests: XCTestCase {
         XCTAssertNotEqual(verdict.internalLevel, .critical,
             "干净设备 + 负 challengeOffset 不得误归 .critical")
     }
+
+    // MARK: - signalWeight minWeight 强制下限（Bug fix 验证）
+
+    /// Bug fix: signalWeight() 当 weightHint > 0 时，之前绕过了 criticalSignalMinWeights
+    /// 的下限约束。修复后使用 max(weightHint, minWeight)，确保关键信号不因低 weightHint 被压低。
+    func testSignalWeightMinWeightEnforcedWithLowWeightHint() {
+        // rop_chain_detected 的 criticalSignalMinWeights = 90
+        // 注入 weightHint=1（远低于 90）的 hard-detected 信号：
+        //   修复前 → weight = 1 → hardScore = 1 → finalScore ≈ 1
+        //   修复后 → weight = max(1, 90) = 90 → hardScore = 90 → finalScore ≈ 90
+        let criticalSignal = RiskSignal(
+            id: "rop_chain_detected",
+            category: "anti_tamper",
+            score: 0,
+            evidence: [:],
+            state: .hard(detected: true),
+            layer: 2,
+            weightHint: 1  // 故意设置低值，应被 minWeight=90 覆盖
+        )
+
+        let engine = RiskDetectionEngine(policy: .default, enableLogging: false)
+        let context = TestFixtures.makeRiskContext()
+        let verdict = engine.evaluate(context: context, extraSignals: [criticalSignal])
+
+        // criticalSignalMinWeights 下限生效后，score 应显著高于 weightHint=1 的原始值
+        XCTAssertGreaterThanOrEqual(verdict.score, 80,
+            "criticalSignalMinWeights 下限应覆盖低 weightHint，score 应 >= 80")
+        XCTAssertLessThanOrEqual(verdict.score, 100)
+    }
+
+    // MARK: - minScore(.allow) 不得抬升分数（Bug fix 验证）
+
+    /// Bug fix: minScore(for: .allow) 之前返回 mediumThreshold（如 50），
+    /// 导致 forceAction=.allow 的组合规则意外将 adjustedScore 抬升到 mediumThreshold。
+    /// 修复后返回 0，forcing .allow 不影响分数。
+    func testMinScoreForAllowComboRuleDoesNotInflateScore() {
+        let allowComboRule = ComboRule(
+            name: "test_force_allow",
+            requiredSignals: ["dummy_allow_test_signal"],
+            bonusScore: 0,
+            forceAction: .allow  // 修复前会把 adjustedScore 抬升到 mediumThreshold
+        )
+        let scenarioPolicy = ScenarioPolicy(
+            mediumThreshold: 50,  // 较高，便于检测意外抬升
+            highThreshold: 70,
+            criticalThreshold: 90,
+            comboRules: [allowComboRule],
+            enableForceRules: true
+        )
+        let enginePolicy = EnginePolicy(
+            scenarioPolicies: [.default: scenarioPolicy]
+        )
+        let dummySignal = RiskSignal(
+            id: "dummy_allow_test_signal",
+            category: "test",
+            score: 3,
+            evidence: [:]
+        )
+
+        let engine = RiskDetectionEngine(policy: enginePolicy, enableLogging: false)
+        let context = TestFixtures.makeRiskContext()
+        let verdict = engine.evaluate(context: context, extraSignals: [dummySignal])
+
+        // 修复前：adjustedScore = max(rawScore, 50) → 至少 50
+        // 修复后：adjustedScore = max(rawScore, 0) → 不被抬升到 50
+        XCTAssertLessThan(verdict.score, 50,
+            "forceAction=.allow 的组合规则不应将 score 抬升到 mediumThreshold (50)")
+    }
+
+    // MARK: - extractPrimaryReasons 优先展示高 weightHint 信号（Bug fix 验证）
+
+    /// Bug fix: 之前 extractPrimaryReasons 按 signal.score 降序排序，
+    /// 导致状态驱动信号（score=0, weightHint=90）被行为信号（score=12）排到末尾。
+    /// 修复后按 max(score, weightHint) 排序，tampered/hard 信号排在最前。
+    func testExtractPrimaryReasonsPrefersTamperedOverLowScoreSignal() {
+        let tamperedSignal = RiskSignal(
+            id: "rop_chain_detected",
+            category: "anti_tamper",
+            score: 0,
+            evidence: [:],
+            state: .tampered,
+            layer: 2,
+            weightHint: 90
+        )
+        let behaviorSignal = RiskSignal(
+            id: "touch_spread_low",
+            category: "behavior",
+            score: 12,
+            evidence: [:],
+            state: nil,
+            weightHint: 0
+        )
+
+        let engine = RiskDetectionEngine(policy: .default, enableLogging: false)
+        let context = TestFixtures.makeRiskContext()
+        // 故意将行为信号放在 tampered 信号之前，验证排序不依赖输入顺序
+        let verdict = engine.evaluate(
+            context: context,
+            extraSignals: [behaviorSignal, tamperedSignal]
+        )
+
+        let reasons = verdict.primaryReasons
+        let tamperedIdx = reasons.firstIndex(where: { $0.contains("rop_chain_detected") })
+        let behaviorIdx = reasons.firstIndex(where: { $0.contains("touch_spread_low") })
+
+        // tampered 信号 max(0, 90)=90 > 行为信号 max(12, 0)=12 → 应排在前面
+        if let ti = tamperedIdx, let bi = behaviorIdx {
+            XCTAssertLessThan(ti, bi,
+                "tampered 信号 (weightHint=90) 应排在行为信号 (score=12) 之前")
+        } else {
+            XCTAssertNotNil(tamperedIdx,
+                "rop_chain_detected tampered 信号应出现在 primaryReasons 中")
+        }
+    }
 }


### PR DESCRIPTION
## 1. signalWeight() — weightHint > 0 时绕过 criticalSignalMinWeights 下限

之前：首个分支直接 `return jitter(base: signal.weightHint, ...)`，
      completey 忽略 `minWeight = criticalSignalMinWeights[signal.id]`。
其余三个分支均正确使用 `max(value, minWeight)`。

后果：若关键信号（rop_chain_detected / vphone_hardware 等）携带低 weightHint （例如来自被篡改的 provider 注入），minWeight 下限形同虚设，信号贡献近乎为零。

修复：`baseWeight = max(signal.weightHint, minWeight)`， 与其他分支保持一致的 minWeight 强制执行语义。

## 2. minScore(for: .allow) 返回 mediumThreshold 而非 0

之前：`case .allow: return scenarioPolicy.mediumThreshold`

后果：若 blocklistAction / comboRule.forceAction 为 .allow， applyForceRules 会执行 `adjustedScore = max(adjustedScore, mediumThreshold)`， 将干净设备的分数强行抬升到中风险阈值（如 30），
并导致 action=.allow 与 internalLevel=.medium 矛盾共存。

修复：`case .allow: return 0`——强制放行不应抬升分数。

## 3. extractPrimaryReasons 按 score 排序，状态驱动信号排末尾

之前：`.sorted { $0.score > $1.score }` — 状态驱动信号（.tampered/.hard） score 统一为 0，真实权重由 weightHint 表达，排序时会被行为信号（score=10/12） 压至末尾，审计记录中的主要原因与实际评分依据脱节。

修复：`.sorted { max($0.score, $0.weightHint) > max($1.score, $1.weightHint) }` 同步修复 RiskDetectionEngine.extractPrimaryReasons 与 RiskVerdict.extractPrimaryReasons。

## 4. CallStackUnwinder — 不必要的 force unwrap

之前：guard 已提前对 `info.dli_fname == nil` 返回，随后仍使用 `info.dli_fname!`。 虽不会 crash，但违反 Swift 惯用法，若 guard 条件被修改则易变成运行时崩溃点。

修复：改为 `guard found != 0, let fname = info.dli_fname else { ... }`， 用 `fname` 替代后续的 force unwrap。

## 5. 新增测试覆盖（ScorePipelineInvariantTests.swift）

- testSignalWeightMinWeightEnforcedWithLowWeightHint： 注入 weightHint=1 的 rop_chain_detected hard-detected 信号， 验证 minWeight=90 生效后 score >= 80（而非 ≈1）。

- testMinScoreForAllowComboRuleDoesNotInflateScore： 使用 forceAction=.allow、mediumThreshold=50 的 comboRule， 验证干净设备 score < 50（不被抬升到 mediumThreshold）。

- testExtractPrimaryReasonsPrefersTamperedOverLowScoreSignal： 同时注入 tampered(score=0, weightHint=90) 与 behavior(score=12, weightHint=0) 信号， 验证 primaryReasons 中 tampered 信号排在行为信号之前。

