### PR TITLE
fix: SDK 6.0 安全加固 — 四处 armor 绕过漏洞修复

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
@@ -208,10 +208,13 @@ static void cprisk_rollback_l(
         if (cprisk_resolve_loader_target(hdr, slide, ent, &target) == 0) {
             uint8_t *ptr = cprisk_target_ptr_l(&target, ent);
             if (ptr) {
-                (void)cprisk_xor_region_l(ptr, (size_t)ent->size, ent->key_id);
                 void *page = NULL;
                 size_t span = 0;
                 cprisk_page_span_l(ptr, (size_t)ent->size, &page, &span);
+                /* Restore write permission before re-encrypting. */
+                if (page && span > 0)
+                    (void)mprotect(page, span, PROT_READ | PROT_WRITE);
+                (void)cprisk_xor_region_l(ptr, (size_t)ent->size, ent->key_id);
                 if (page && span > 0)
                     munlock(page, span);
             }
@@ -303,8 +306,12 @@ int cprisk_load_protected_data(void) {
         void *page = NULL;
         size_t span = 0;
         cprisk_page_span_l(ptr, (size_t)ent->size, &page, &span);
-        if (page && span > 0)
+        if (page && span > 0) {
             (void)mlock(page, span);
+            /* Remove write permission from decrypted pages so an attacker
+             * cannot silently patch detection logic in memory. */
+            (void)mprotect(page, span, PROT_READ);
+        }
 
         memcpy(&applied[applied_count], ent, sizeof(*ent));
         applied_count++;
@@ -343,11 +350,13 @@ void cprisk_unload_protected_data(void) {
                 if (!ptr)
                     continue;
 
-                (void)cprisk_xor_region_l(ptr, (size_t)ent->size, ent->key_id);
-
                 void *page = NULL;
                 size_t span = 0;
                 cprisk_page_span_l(ptr, (size_t)ent->size, &page, &span);
+                /* Restore write permission before re-encrypting. */
+                if (page && span > 0)
+                    (void)mprotect(page, span, PROT_READ | PROT_WRITE);
+                (void)cprisk_xor_region_l(ptr, (size_t)ent->size, ent->key_id);
                 if (page && span > 0)
                     munlock(page, span);
             }

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_integrity.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_integrity.c
@@ -22,6 +22,10 @@ _Static_assert(CPRISK_SHA256_DIGEST_LENGTH == CPRISK_ARMOR_HASH_SIZE,
 static uint8_t s_runtime_material[CPRISK_ARMOR_HASH_SIZE];
 static int s_runtime_material_ready;
 
+/* Per-execution random value filled on first poison use; never a public constant. */
+static uint8_t s_poison_material[CPRISK_ARMOR_HASH_SIZE];
+static int s_poison_material_ready;
+
 static void cprisk_szero_i(void *p, size_t n) {
     volatile uint8_t *v = (volatile uint8_t *)p;
     while (n--) *v++ = 0;
@@ -308,6 +312,20 @@ int cprisk_init_protection(const uint8_t *root_key, size_t root_key_len) {
     int rc = -1;
 
     cprisk_fill_root_material_i(root_key, root_key_len, root_material);
+
+    /* Reject NULL or all-zero root keys: an all-zero key makes the full
+     * armor chain deterministic for any attacker who can read __TEXT. */
+    {
+        int all_zero = 1;
+        for (int zi = 0; zi < CPRISK_ARMOR_KEY_SIZE; zi++) {
+            if (root_material[zi] != 0) { all_zero = 0; break; }
+        }
+        if (all_zero) {
+            rc = -1;
+            goto cleanup;
+        }
+    }
+
     cprisk_derive_string_key_i(root_material, string_key);
     if (cprisk_init_string_decryptor(string_key, CPRISK_ARMOR_KEY_SIZE) != 0) {
         rc = -2;
@@ -379,6 +397,9 @@ cleanup:
 void cprisk_cleanup_protection(void) {
     cprisk_szero_i(s_runtime_material, sizeof(s_runtime_material));
     s_runtime_material_ready = 0;
+    /* Invalidate the per-run poison so a new random is drawn on next use. */
+    cprisk_szero_i(s_poison_material, sizeof(s_poison_material));
+    s_poison_material_ready = 0;
     cprisk_cleanup_string_decryptor();
     cprisk_unload_protected_data();
 }
@@ -393,15 +414,15 @@ int cprisk_get_runtime_material(uint8_t out_material[32]) {
     }
 
     /*
-     * Poison path: deterministic but WRONG 32-byte value.
-     * Any signature derived from this will fail server-side verification.
+     * Poison path: per-execution random 32-byte value, generated once on first
+     * use via arc4random_buf.  Using a public constant here would let an attacker
+     * pre-compute HMAC(key=constant, msg=baseKey) after forcing cleanup, so we
+     * keep this value secret and unpredictable per process run.
      */
-    static const uint8_t poison_seed[32] = {
-        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
-        0x13, 0x37, 0x42, 0x42, 0xFE, 0xED, 0xFA, 0xCE,
-        0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89,
-        0x98, 0x76, 0x54, 0x32, 0x10, 0xFE, 0xDC, 0xBA
-    };
-    memcpy(out_material, poison_seed, CPRISK_ARMOR_HASH_SIZE);
+    if (!s_poison_material_ready) {
+        arc4random_buf(s_poison_material, CPRISK_ARMOR_HASH_SIZE);
+        s_poison_material_ready = 1;
+    }
+    memcpy(out_material, s_poison_material, CPRISK_ARMOR_HASH_SIZE);
     return -1;
 }

--- a/RiskDetectorApp/Sources/CRiskCore/include/CRiskCore.h
+++ b/RiskDetectorApp/Sources/CRiskCore/include/CRiskCore.h
@@ -146,9 +146,9 @@ int cprisk_read_full_anchor_hash(uint8_t *out_hash);
 
 /// Master initialization: pass1 bootstrap string → pass4 integrity/anchor
 /// material → pass3 loader key derivation → decrypt protected data.
-/// root_key is optional entropy: NULL/0-length is allowed and treated as
-/// all-zero padding; longer values are truncated to 32 bytes.
-/// Returns 0 on success, negative on failure.
+/// root_key must be non-NULL and non-zero (all-zero keys are rejected with -1
+/// to prevent a predictable key chain); values longer than 32 bytes are
+/// truncated. Returns 0 on success, negative on failure.
 int cprisk_init_protection(const uint8_t *root_key, size_t root_key_len);
 
 /// Cleanup all armor runtime state (keys, accumulators, decrypted data).
@@ -156,7 +156,8 @@ void cprisk_cleanup_protection(void);
 
 /// Retrieve the 32-byte runtime material derived from the full armor init chain.
 /// If armor runtime is not initialized or was tampered, out_material will be
-/// filled with a deterministic poison value derived from the init state.
+/// filled with a per-execution random poison value (generated via arc4random_buf
+/// on first use; never a public constant).
 /// Always writes exactly 32 bytes to out_material. Returns 0 if material is
 /// authentic (init succeeded), -1 if poisoned (init failed/skipped).
 int cprisk_get_runtime_material(uint8_t out_material[32]);

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/CloudPhoneRiskKit.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/CloudPhoneRiskKit.swift
@@ -114,11 +114,11 @@ public final class CPRiskKit: NSObject {
 
     private enum ArmorRootKeySource: String {
         case environment
-        case userDefaults
+
         case debugFallback
         case missing
         case invalidEnvironment
-        case invalidUserDefaults
+
     }
 
     private enum ArmorRuntimeStatus: String {
@@ -169,7 +169,7 @@ public final class CPRiskKit: NSObject {
     }
 
     private static let armorRootKeyEnvironmentKey = "CPRISKKIT_ARMOR_ROOT_KEY_HEX"
-    private static let armorRootKeyDefaultsKey = "com.cloudphone.riskkit.armor.root_key_hex"
+
 #if DEBUG
     private static let armorDebugFallbackRootKeyHex = "00112233445566778899aabbccddeeff102132435465768798a9bacbdcedfe0f"
 #endif
@@ -1616,31 +1616,6 @@ public final class CPRiskKit: NSObject {
             )
         }
 
-        if let rawValue = UserDefaults.standard.string(forKey: armorRootKeyDefaultsKey) {
-            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
-                return ArmorRootKeyResolution(
-                    keyData: nil,
-                    source: .invalidUserDefaults,
-                    debugFallbackUsed: false,
-                    failureReason: "invalid_root_key_hex"
-                )
-            }
-            guard let keyData = Data(hexString: trimmed), keyData.count == 32 else {
-                return ArmorRootKeyResolution(
-                    keyData: nil,
-                    source: .invalidUserDefaults,
-                    debugFallbackUsed: false,
-                    failureReason: "invalid_root_key_hex"
-                )
-            }
-            return ArmorRootKeyResolution(
-                keyData: keyData,
-                source: .userDefaults,
-                debugFallbackUsed: false,
-                failureReason: nil
-            )
-        }
 
 #if DEBUG
         return ArmorRootKeyResolution(


### PR DESCRIPTION
P0 — Bug1：删除 UserDefaults 根密钥读取路径
  攻击者在同进程（Frida hook）写入已知密钥至 UserDefaults，
  即可让整条 armor 密钥链可预测，伪造 runtime_material。
  修复：resolveArmorRootKey() 移除 UserDefaults 分支，
        仅保留环境变量与 #if DEBUG 回退；
        删除 armorRootKeyDefaultsKey 常量及对应 enum case。

P0 — Bug2：毒化种子改为 per-run arc4random_buf
  cprisk_get_runtime_material() 在 !s_runtime_material_ready 时
  曾返回公开硬编码常量 {0xDE,0xAD,0xBE,0xEF,...}。
  攻击者通过 Frida 调用 cprisk_cleanup_protection() 后读取
  armorMaterial = 已知常量，即可预计算 HMAC 伪造签名。
  修复：引入 s_poison_material（per-process-run），首次使用时
        用 arc4random_buf 初始化；cprisk_cleanup_protection()
        同时清零并重置，使每次运行毒化值不可预测。

P1 — Bug3：拒绝 NULL/全零 root key
  cprisk_init_protection(NULL/零长) 静默填充全零 root_material，
  整条派生链退化为 SHA256(label || zeros || integrity_hash || ...)，
  jailbroken 设备上攻击者自行计算 __TEXT hash 即可完全预测
  s_runtime_material。
  修复：cprisk_init_protection() 在填充后检测全零 root_material，
        发现时提前返回 -1（invalid_root_key）；
        更新 CRiskCore.h 注释说明 NULL 不再被接受。

P1 — Bug4：解密后保护页面只读，rollback/unload 前恢复写权限
  cprisk_load_protected_data() mlock 后从未调用 mprotect(PROT_READ)，
  解密后的 __DATA 节终生可写，攻击者可直接 patch 检测逻辑。
  修复：mlock 后紧接 mprotect(PROT_READ)；
        cprisk_rollback_l() 与 cprisk_unload_protected_data() 在
        re-XOR 前先 mprotect(PROT_READ | PROT_WRITE)，完成后 munlock。

