### PR TITLE
fix: SDK 6.1 安全加固 — 三处漏洞修复

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_integrity.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_integrity.c
@@ -38,7 +38,6 @@ static int s_integrity_hash_saved;
 static int s_integrity_poisoned;
 
 static uint64_t s_init_elapsed_ns;
->>>>>>> dc37570 (feat: SDK 6.1 — 壳工业化 (5 Pass) + 运行时加固 + 全量回归)
 
 static const struct mach_header_64 *cprisk_own_hdr_i(void) {
     return cprisk_find_own_header((const void *)cprisk_own_hdr_i);

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_memory_guard.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_memory_guard.c
@@ -144,7 +144,12 @@ int cprisk_install_memory_trap(void *region, size_t len,
         planted++;
     }
 
-    state->pages_protected = 1;
+    /* Only mark traps as active when at least one guard page was actually
+     * installed.  VM_FLAGS_FIXED allocation fails when the adjacent pages are
+     * already mapped (standard in any __DATA segment), so planted may be 0.
+     * Setting pages_protected=1 unconditionally masks this silent failure and
+     * misleads any caller that inspects state->pages_protected. */
+    state->pages_protected = (planted > 0) ? 1 : 0;
     return planted;
 }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/CloudPhoneRiskKit.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/CloudPhoneRiskKit.swift
@@ -1804,7 +1804,7 @@ public final class CPRiskKit: NSObject {
     /// 返回 v2a 信封验签所需的派生密钥。
     /// 确保 armor runtime 已启动，并用 baseKey + armor material 派生。
     /// 供 validateSecureReportEnvelope 在 sigVer == "v2a" 时使用。
-    internal func effectiveSigningKeyForV2aValidation(baseKey: String) -> String {
+    private func effectiveSigningKeyForV2aValidation(baseKey: String) -> String {
         _ = ensureArmorRuntimeStarted(trigger: "validate_envelope")
         let (armorMaterial, _) = Self.armorRuntimeMaterial()
         return Self.deriveEffectiveSigningKey(baseKey: baseKey, armorMaterial: armorMaterial)


### PR DESCRIPTION
P0 — Bug1：删除 cprisk_integrity.c 遗留的 git 冲突标记（编译报错）
  第 41 行残留 ">>>>>>> dc37570 (feat: SDK 6.1 ...)" 标记，
  C 编译器无法解析，导致整个 SDK 构建失败。
  修复：删除该行。

P1 — Bug2：effectiveSigningKeyForV2aValidation 改为 private
  新增方法标记为 internal，使模块内任意代码（含 Frida 注入的
  测试框架）均可调用并直接获取 v2a 派生签名密钥（String 返回值），
  攻击者凭此伪造合法信封签名，完全绕过 armor 保护链。
  修复：internal → private；同一 CPRiskKit extension 内的
        SecureEnvelopeValidator 仍可正常调用。

P1 — Bug3：cprisk_install_memory_trap 陷阱页静默安装失败
  VM_FLAGS_FIXED 要求目标地址空闲，而标准 Mach-O __DATA segment
  中被保护 section 的前后页早已被同 segment 其他节占用，
  vm_allocate 必然返回 KERN_NO_SPACE，planted 始终为 0。
  但随后 state->pages_protected = 1 被无条件设置，调用方
  （以及 cprisk_recheck_integrity 等监控路径）无法感知
  陷阱从未安装，反蜜罐保护形同虚设。
  修复：pages_protected 仅在 planted > 0 时设为 1，
        准确反映实际安装状态。

