### PR TITLE
fix: SDK 6.3 审查 — 三处安全漏洞修复

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
@@ -188,7 +188,10 @@ static int cprisk_parse_loader_descriptor(
         return -1;
     size_t entries_base = sizeof(struct cprisk_armor_loader_header);
     size_t entries_sz = (size_t)count * sizeof(struct cprisk_armor_loader_entry);
-    if (entries_base + entries_sz > (size_t)sec_sz)
+    if (count > 0 && entries_sz / sizeof(struct cprisk_armor_loader_entry) != (size_t)count)
+        return -1;  /* multiplication overflow */
+    if (entries_base + entries_sz < entries_base ||
+        entries_base + entries_sz > (size_t)sec_sz)
         return -1;
 
     *count_out = count;

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_string_decrypt.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_string_decrypt.c
@@ -143,6 +143,7 @@ int cprisk_decrypt_string(uint32_t string_id, char *buffer, size_t buffer_size) 
         return -1;
     if ((size_t)ent->data_offset > sec_sz ||
         (size_t)dlen > sec_sz ||
+        data_base > sec_sz ||
         data_end > sec_sz - data_base)
         return -1;
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskSignalProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskSignalProvider.swift
@@ -167,7 +167,7 @@ final class RiskSignalProviderRegistry {
             out.append(RiskSignal(
                 id: "provider_tamper_attempt",
                 category: "anti_tamper",
-                score: 0,
+                score: 85,
                 evidence: ["attempts": "\(unregisterAttempts)"],
                 state: .tampered,
                 layer: 2,
@@ -180,7 +180,7 @@ final class RiskSignalProviderRegistry {
             out.append(RiskSignal(
                 id: "provider_instance_replaced",
                 category: "anti_tamper",
-                score: 0,
+                score: 85,
                 evidence: ["providers": ids],
                 state: .tampered,
                 layer: 2,


### PR DESCRIPTION
1. RiskSignalProvider: 篡改信号 score:0 → score:85 provider_tamper_attempt 和 provider_instance_replaced 两个信号 的 score 均为 0，导致 provider hook/替换行为对实际风险评分贡献 为零（RiskScorer 使用 signal.score，weightHint 仅为提示）。 改为 score:85，与 weightHint 保持一致，使篡改行为能实际触发 高风险决策。

2. cprisk_string_decrypt.c: 修复 sec_sz - data_base 无符号下溢 当 data_base > sec_sz 时，`data_end > sec_sz - data_base` 中的 `sec_sz - data_base` 发生 size_t 无符号下溢，回绕为巨大值， 导致边界检查被绕过。在执行减法前新增 `data_base > sec_sz` 的 显式检查。

