### PR TITLE
fix: 全局审查 commit 4d77782 — 四处 CRiskCore 安全/内存 bug 修复

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
@@ -319,6 +319,8 @@ static int cprisk_page_span_l(uint8_t *target, size_t sz,
         return -1;
     if ((uintptr_t)target > UINTPTR_MAX - sz)
         return -1;
+    if ((uintptr_t)target + sz > UINTPTR_MAX - 0xFFF)
+        return -1;
     uintptr_t page = (uintptr_t)target & ~(uintptr_t)0xFFF;
     uintptr_t end = ((uintptr_t)target + sz + 0xFFF) & ~(uintptr_t)0xFFF;
     *page_out = (void *)page;
@@ -400,6 +402,8 @@ int cprisk_load_protected_data(void) {
             return -1;
         }
         pthread_mutex_lock(&s_loader_mutex);
+        free(s_applied_entries);
+        free(s_decrypted_flags);
         s_applied_entries = entries_tmp;
         s_decrypted_flags = flags_tmp;
         s_applied_count = 0;

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_image_check.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_image_check.c
@@ -41,8 +41,11 @@ int cprisk_addr_in_any_image(const void *addr) {
         if (!hdr) continue;
 
         if (hdr->magic != MH_MAGIC_64) continue;
+        /* Guard against corrupt sizeofcmds causing pointer overflow */
+        if (hdr->sizeofcmds > 0x100000u) continue;
 
         intptr_t slide = 0;
+        int found_text = 0;
         const uint8_t *p = (const uint8_t *)(hdr + 1);
         const uint8_t *end = (const uint8_t *)hdr + sizeof(struct mach_header_64) + hdr->sizeofcmds;
 
@@ -56,13 +59,14 @@ int cprisk_addr_in_any_image(const void *addr) {
                 const struct segment_command_64 *seg = (const struct segment_command_64 *)p;
                 if (segname_eq(seg->segname, "__TEXT", 16)) {
                     slide = (intptr_t)hdr - (intptr_t)seg->vmaddr;
+                    found_text = 1;
                     break;
                 }
             }
             p += lc->cmdsize;
         }
 
-        if (slide == 0) continue;
+        if (!found_text) continue;
 
         /* Second pass: check each segment */
         p = (const uint8_t *)(hdr + 1);

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_string_decrypt.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_string_decrypt.c
@@ -137,7 +137,7 @@ int cprisk_decrypt_string(uint32_t string_id, char *buffer, size_t buffer_size) 
         return -1;
 
     uint32_t dlen = ent->data_length;
-    if (dlen == 0 || dlen + 1 > buffer_size)
+    if (dlen == 0 || dlen >= buffer_size)
         return -1;
     size_t data_block_sz = sec_sz - data_base;
     size_t data_end = (size_t)ent->data_offset + (size_t)dlen;


### PR DESCRIPTION
A. cprisk_image_check.c — 两处逻辑/安全问题
   1. slide==0 误跳过：用布尔标志 found_text 替换 `slide==0` 作为 "未找到 __TEXT" 的哨兵。原代码在 slide 恰好为 0（镜像加载于 首选地址，iOS 模拟器常见）时会跳过整个镜像，导致 dladdr-free 地址检查漏判。
   2. sizeofcmds 无上界：添加 `hdr->sizeofcmds > 0x100000` 检查， 防止恶意 Mach-O 通过极大值触发 `(uint8_t *)hdr + sizeofcmds` 指针运算溢出，使后续 `p > end` 边界保护失效。

B. cprisk_data_loader.c — 两处问题
   1. page_span_l +0xFFF 二次溢出：现有检查仅保证 `target+sz` 不 溢出，但随后的 `+0xFFF` 未再检查，当 `target+sz` 位于 `[UINTPTR_MAX-0xFFF, UINTPTR_MAX]` 区间时发生回绕，导致 page_out/len_out 计算错误，进而影响 mprotect 范围。新增 `target+sz > UINTPTR_MAX-0xFFF` 前卫检查。
   2. 重新初始化内存泄漏：当 cprisk_init_data_loader 被再次调用 （重置 s_ldr_loaded=0）后重新进入 cprisk_load_protected_data， s_applied_entries/s_decrypted_flags 旧指针在互斥锁内直接被 覆盖而未 free，造成堆内存泄漏。在赋值前加 free() 调用。

C. cprisk_string_decrypt.c — dlen+1 uint32 回绕
   `dlen+1 > buffer_size` 当 dlen=UINT32_MAX 时，uint32 加法回绕
   为 0，使检查 `0 > buffer_size` 恒为 false，后续 `buffer[dlen]='\0'`
