### PR TITLE
fix: SDK 6.4 审查 — 6 处 bug 修复 + 缺失测试补全

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/AnomalyDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/AnomalyDetector.swift
@@ -183,12 +183,9 @@ public final class AnomalyDetector {
         let sorted = samples.sorted()
         let count = sorted.count
 
-        // 计算四分位数
-        let q1Index = count / 4
-        let q3Index = (3 * count) / 4
-
-        let q1 = sorted[min(q1Index, count - 1)]
-        let q3 = sorted[min(q3Index, count - 1)]
+        // 计算四分位数（线性插值，与统计标准一致）
+        let q1 = interpolatedPercentile(sorted: sorted, p: 0.25)
+        let q3 = interpolatedPercentile(sorted: sorted, p: 0.75)
         let iqr = q3 - q1
 
         guard iqr > 0 else {
@@ -438,4 +435,17 @@ private func pow(_ base: Double, _ exp: Double) -> Double {
 
 private func sqrt(_ x: Double) -> Double {
     return Darwin.sqrt(x)
+}
+
+/// 线性插值分位数（等同于 numpy percentile method='linear'）
+private func interpolatedPercentile(sorted: [Double], p: Double) -> Double {
+    guard !sorted.isEmpty else { return 0 }
+    let n = Double(sorted.count)
+    let index = p * (n - 1)
+    let lower = Int(Darwin.floor(index))
+    let upper = Int(Darwin.ceil(index))
+    guard lower >= 0, upper < sorted.count else { return sorted[max(0, min(lower, sorted.count - 1))] }
+    if lower == upper { return sorted[lower] }
+    let weight = index - Double(lower)
+    return sorted[lower] * (1.0 - weight) + sorted[upper] * weight
 }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/BehaviorBaseline.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/BehaviorBaseline.swift
@@ -99,7 +99,7 @@ public struct StatisticalFeatures: Codable, Sendable {
         let index = (p / 100.0) * (count - 1)
         let lower = Int(floor(index))
         let upper = Int(ceil(index))
-        guard lower >= 0, upper < sorted.count else { return sorted[0] }
+        guard lower >= 0, upper < sorted.count else { return 0 }
 
         if lower == upper {
             return sorted[lower]

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
@@ -466,7 +466,7 @@ public final class DeviceHistory {
             return
         }
 
-        if diskFreshness.sequence < anchor.sequence || diskFreshness.latestTimestamp < anchor.latestTimestamp {
+        if diskFreshness.sequence < anchor.sequence && diskFreshness.latestTimestamp < anchor.latestTimestamp {
             Logger.log("DeviceHistory: freshness rollback detected")
             clearPersistedFilesLocked(resetAnchor: false)
             cachedSnapshots = []

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/TemporalFeatures.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/TemporalFeatures.swift
@@ -237,7 +237,11 @@ public final class TemporalFeaturesCalculator {
         let sumXY = zip(xValues, scores).map(*).reduce(0, +)
         let sumXX = xValues.map { $0 * $0 }.reduce(0, +)
 
-        let slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX)
+        let denominator = n * sumXX - sumX * sumX
+        guard abs(denominator) > 1e-9 else {
+            return .stable
+        }
+        let slope = (n * sumXY - sumX * sumY) / denominator
         let avgScore = sumY / n
 
         // 根据斜率判断趋势

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/UploadPolicy.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/UploadPolicy.swift
@@ -115,8 +115,8 @@ public struct UploadPolicy: Codable, Sendable {
             baseDelay = config.lowRiskBatchInterval
         }
 
-        // 添加随机抖动
-        let jitter = baseDelay * config.jitterRatio * Double.random(in: -1...1)
+        // 添加随机抖动（±0.5 范围，避免抖动量超过延迟本身）
+        let jitter = baseDelay * config.jitterRatio * Double.random(in: -0.5...0.5)
         return max(0, baseDelay + jitter)
     }
 

--- a/RiskDetectorApp/Tests/CloudPhoneRiskAppCoreTests/RiskReportMapperTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskAppCoreTests/RiskReportMapperTests.swift
@@ -167,6 +167,129 @@ final class RiskReportMapperTests: XCTestCase {
         XCTAssertTrue(cloudDatacenter?.detected ?? false)
     }
 
+    // MARK: - graphPayload mapping (Bug fix: commit 54881e1)
+
+    /// 验证 graphPayload 字段在 PayloadMirror 解码后正确传递到 RiskReportDTO
+    /// 回归测试：此前 RiskReportMapper 在 dto(from:jsonData:) 路径中
+    /// 将 graphPayload 静默丢弃（未传入 RiskReportDTO 构造器）
+    func testDtoFromJSONData_GraphPayloadMappedCorrectly() {
+        let json = """
+        {
+          "generatedAt": "2024-01-15T10:00:00.000Z",
+          "deviceID": "test-device-graph",
+          "score": 42.0,
+          "isHighRisk": false,
+          "summary": "medium_risk",
+          "network": {
+            "interfaceType": {"value": "wifi", "method": "NWPathMonitor"},
+            "isExpensive": false,
+            "isConstrained": false,
+            "vpn": {"detected": false, "method": "ifaddrs", "confidence": "weak"},
+            "proxy": {"detected": false, "method": "CFNetwork", "confidence": "weak"}
+          },
+          "behavior": {
+            "touch": {"sampleCount": 0, "tapCount": 0, "swipeCount": 0},
+            "motion": {"sampleCount": 0},
+            "touchMotionCorrelation": null,
+            "actionCount": 0
+          },
+          "jailbreak": {
+            "isJailbroken": false,
+            "confidence": 0,
+            "detectedMethods": [],
+            "details": ""
+          },
+          "signals": [],
+          "graphPayload": {
+            "fingerprintVector": {
+              "hwEntropy": 5.5,
+              "screenRatioDrift": 0.02,
+              "cpuCoreConsistency": 0.95,
+              "bootTimeDelta": 72000,
+              "gpuTier": 2
+            },
+            "edgeSignals": {
+              "ipSubnet": "192.168.1",
+              "carrierASN": 4134,
+              "timezoneOffset": 28800,
+              "locale": "zh_CN"
+            },
+            "temporalRhythm": {
+              "sessionSeq": 3,
+              "installAgeDays": 30,
+              "tapIntervalP50": 250.0,
+              "sessionDurationP50": 120.0
+            },
+            "capabilityScore": {
+              "basicAnomalyCount": 0,
+              "qualitySuspicion": 10,
+              "totalProbes": 8
+            }
+          }
+        }
+        """
+        guard let data = json.data(using: .utf8) else {
+            XCTFail("JSON data encoding failed")
+            return
+        }
+
+        let dto = RiskReportMapper.dto(from: data)
+
+        XCTAssertNotNil(dto, "DTO should not be nil")
+        XCTAssertNotNil(dto?.graphPayload, "graphPayload should be decoded and mapped, not silently dropped")
+
+        let gp = dto?.graphPayload
+        XCTAssertEqual(gp?.fingerprintVector.hwEntropy, 5.5, accuracy: 0.001)
+        XCTAssertEqual(gp?.fingerprintVector.gpuTier, 2)
+        XCTAssertEqual(gp?.edgeSignals.ipSubnet, "192.168.1")
+        XCTAssertEqual(gp?.edgeSignals.carrierASN, 4134)
+        XCTAssertEqual(gp?.temporalRhythm.sessionSeq, 3)
+        XCTAssertEqual(gp?.temporalRhythm.installAgeDays, 30)
+        XCTAssertEqual(gp?.capabilityScore.qualitySuspicion, 10)
+        XCTAssertEqual(gp?.capabilityScore.totalProbes, 8)
+    }
+
+    /// 验证 graphPayload 为 nil 时不影响其他字段映射
+    func testDtoFromJSONData_GraphPayloadAbsentMapsToNil() {
+        let json = """
+        {
+          "generatedAt": "2024-01-15T10:00:00.000Z",
+          "deviceID": "test-no-graph",
+          "score": 10.0,
+          "isHighRisk": false,
+          "summary": "low_risk",
+          "network": {
+            "interfaceType": {"value": "wifi", "method": "NWPathMonitor"},
+            "isExpensive": false,
+            "isConstrained": false,
+            "vpn": {"detected": false, "method": "ifaddrs", "confidence": "weak"},
+            "proxy": {"detected": false, "method": "CFNetwork", "confidence": "weak"}
+          },
+          "behavior": {
+            "touch": {"sampleCount": 0, "tapCount": 0, "swipeCount": 0},
+            "motion": {"sampleCount": 0},
+            "touchMotionCorrelation": null,
+            "actionCount": 0
+          },
+          "jailbreak": {
+            "isJailbroken": false,
+            "confidence": 0,
+            "detectedMethods": [],
+            "details": ""
+          },
+          "signals": []
+        }
+        """
+        guard let data = json.data(using: .utf8) else {
+            XCTFail("JSON data encoding failed")
+            return
+        }
+
+        let dto = RiskReportMapper.dto(from: data)
+        XCTAssertNotNil(dto)
+        XCTAssertNil(dto?.graphPayload, "graphPayload should be nil when absent from JSON")
+    }
+
     func testDtoFromReport_RoundtripViaJSON() {
         let context = TestFixtures.makeRiskContext()
         let report = RiskScorer.score(context: context, config: TestFixtures.defaultRiskConfig)

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/AnalysisAndUploadPolicyTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/AnalysisAndUploadPolicyTests.swift
@@ -1,0 +1,324 @@
+import XCTest
+@testable import CloudPhoneRiskKit
+
+// MARK: - UploadPolicy Tests
+
+final class UploadPolicyTests: XCTestCase {
+
+    let policy = UploadPolicy()
+
+    // MARK: riskLevel
+
+    func testHighRiskLevel() {
+        XCTAssertEqual(policy.riskLevel(for: 80), .high)
+        XCTAssertEqual(policy.riskLevel(for: 100), .high)
+        XCTAssertEqual(policy.riskLevel(for: 99), .high)
+    }
+
+    func testMediumRiskLevel() {
+        XCTAssertEqual(policy.riskLevel(for: 50), .medium)
+        XCTAssertEqual(policy.riskLevel(for: 79), .medium)
+        XCTAssertEqual(policy.riskLevel(for: 65), .medium)
+    }
+
+    func testLowRiskLevel() {
+        XCTAssertEqual(policy.riskLevel(for: 0), .low)
+        XCTAssertEqual(policy.riskLevel(for: 49), .low)
+        XCTAssertEqual(policy.riskLevel(for: 30), .low)
+    }
+
+    func testBoundaryThresholds() {
+        XCTAssertEqual(policy.riskLevel(for: 80), .high)
+        XCTAssertEqual(policy.riskLevel(for: 50), .medium)
+        XCTAssertEqual(policy.riskLevel(for: 49), .low)
+    }
+
+    // MARK: shouldImmediateUpload / shouldBatch
+
+    func testShouldImmediateUploadHighRisk() {
+        XCTAssertTrue(policy.shouldImmediateUpload(score: 85))
+        XCTAssertFalse(policy.shouldImmediateUpload(score: 60))
+        XCTAssertFalse(policy.shouldImmediateUpload(score: 20))
+    }
+
+    func testShouldBatchLowRisk() {
+        XCTAssertTrue(policy.shouldBatch(score: 20))
+        XCTAssertFalse(policy.shouldBatch(score: 60))
+        XCTAssertFalse(policy.shouldBatch(score: 90))
+    }
+
+    // MARK: calculateDelay — bounds
+
+    func testCalculateDelayHighRiskNonNegative() {
+        for _ in 0..<50 {
+            let delay = policy.calculateDelay(for: 90)
+            XCTAssertGreaterThanOrEqual(delay, 0, "延迟不得为负")
+        }
+    }
+
+    func testCalculateDelayLowRiskStaysBounded() {
+        // lowRiskBatchInterval=300, jitterRatio=0.2, jitter factor max=±0.5
+        // max jitter = 300 * 0.2 * 0.5 = 30 → delay ∈ [270, 330]
+        let config = UploadPolicy.PolicyConfig(
+            highRiskDelayRange: 0...2,
+            mediumRiskDelayRange: 30...120,
+            lowRiskBatchInterval: 300,
+            jitterRatio: 0.2
+        )
+        let p = UploadPolicy(config: config)
+        for _ in 0..<100 {
+            let delay = p.calculateDelay(for: 10)
+            XCTAssertGreaterThanOrEqual(delay, 0)
+            // Max possible: 300 + 300*0.2*0.5 = 330
+            XCTAssertLessThanOrEqual(delay, 330.001, "抖动不应超过 ±0.5×jitterRatio×base")
+        }
+    }
+
+    // MARK: strict / lenient presets
+
+    func testStrictPresetHigherSensitivity() {
+        XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 70), .high)
+        XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 69), .medium)
+    }
+
+    func testLenientPresetLowerSensitivity() {
+        XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 89), .medium)
+        XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 90), .high)
+    }
+
+    // MARK: nextBatchDelay
+
+    func testNextBatchDelayInFuture() {
+        let now = Date().timeIntervalSince1970
+        let delay = policy.nextBatchDelay(since: now)
+        // batch interval = 300s, just started → remaining ≈ 300
+        XCTAssertGreaterThan(delay, 290)
+        XCTAssertLessThanOrEqual(delay, 300.1)
+    }
+
+    func testNextBatchDelayElapsed() {
+        let past = Date().timeIntervalSince1970 - 400
+        let delay = policy.nextBatchDelay(since: past)
+        XCTAssertEqual(delay, 0, "已过期应返回 0")
+    }
+}
+
+// MARK: - AnomalyDetector Tests
+
+final class AnomalyDetectorTests: XCTestCase {
+
+    let detector = AnomalyDetector()
+
+    // MARK: Z-score
+
+    func testZScoreInsufficientSamples() {
+        let result = detector.detectZScore(value: 100, samples: [1, 2])
+        XCTAssertFalse(result.isAnomalous)
+        XCTAssertEqual(result.zScore, 0)
+    }
+
+    func testZScoreNotAnomalous() {
+        let samples = [10.0, 10.0, 10.0, 10.0, 10.0]
+        // All values equal → stdDev = 0 → not anomalous
+        let result = detector.detectZScore(value: 10, samples: samples)
+        XCTAssertFalse(result.isAnomalous)
+    }
+
+    func testZScoreAnomalousOutlier() {
+        let samples = Array(repeating: 10.0, count: 20) + [10.0, 10.0, 10.0]
+        let result = detector.detectZScore(value: 100.0, samples: samples, threshold: 2.0)
+        XCTAssertTrue(result.isAnomalous)
+        XCTAssertGreaterThan(result.zScore, 2.0)
+    }
+
+    func testZScoreNormalValue() {
+        let samples = [10.0, 12.0, 11.0, 13.0, 10.0, 11.0, 12.0, 13.0, 11.0, 10.0]
+        let result = detector.detectZScore(value: 11.5, samples: samples, threshold: 3.0)
+        XCTAssertFalse(result.isAnomalous)
+    }
+
+    // MARK: IQR
+
+    func testIQRInsufficientSamples() {
+        let result = detector.detectIQR(value: 50, samples: [1, 2, 3])
+        XCTAssertFalse(result.isAnomalous)
+    }
+
+    func testIQRNormalValue() {
+        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+        let result = detector.detectIQR(value: 45.0, samples: samples)
+        XCTAssertFalse(result.isAnomalous)
+    }
+
+    func testIQRHighOutlier() {
+        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+        let result = detector.detectIQR(value: 200.0, samples: samples)
+        XCTAssertTrue(result.isAnomalous)
+        XCTAssertTrue(result.isAboveUpperBound)
+        XCTAssertFalse(result.isBelowLowerBound)
+    }
+
+    func testIQRLowOutlier() {
+        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+        let result = detector.detectIQR(value: -100.0, samples: samples)
+        XCTAssertTrue(result.isAnomalous)
+        XCTAssertTrue(result.isBelowLowerBound)
+    }
+
+    /// Q1/Q3 should be computed via linear interpolation, not raw integer index.
+    /// For sorted=[10,20,30,40,50]: correct Q1=17.5, Q3=42.5
+    func testIQRInterpolationCorrectness() {
+        let samples = [30.0, 10.0, 50.0, 20.0, 40.0] // sorted: [10,20,30,40,50]
+        let result = detector.detectIQR(value: 30.0, samples: samples)
+        // Q1 = interpolated 25th percentile of [10,20,30,40,50] = 17.5
+        // Q3 = interpolated 75th percentile = 42.5
+        // IQR = 25, lower = 17.5 - 1.5*25 = -20, upper = 42.5 + 1.5*25 = 80
+        XCTAssertFalse(result.isAnomalous, "30 should be within IQR bounds")
+        XCTAssertEqual(result.lowerBound, -20.0, accuracy: 0.01)
+        XCTAssertEqual(result.upperBound, 80.0, accuracy: 0.01)
+    }
+
+    func testIQRAllSameValues() {
+        // IQR = 0 → no anomaly detection possible
+        let samples = [5.0, 5.0, 5.0, 5.0, 5.0]
+        let result = detector.detectIQR(value: 5.0, samples: samples)
+        XCTAssertFalse(result.isAnomalous)
+    }
+}
+
+// MARK: - StatisticalFeatures / BehaviorBaseline Tests
+
+final class StatisticalFeaturesTests: XCTestCase {
+
+    // MARK: percentile interpolation via StatisticalFeatures.from
+
+    func testPercentile25SingleElement() {
+        let features = StatisticalFeatures.from([42.0])
+        XCTAssertNotNil(features)
+        XCTAssertEqual(features!.percentile25, 42.0, accuracy: 0.001)
+        XCTAssertEqual(features!.percentile75, 42.0, accuracy: 0.001)
+    }
+
+    func testPercentileInterpolationFiveElements() {
+        // sorted: [10, 20, 30, 40, 50]
+        let features = StatisticalFeatures.from([30.0, 10.0, 50.0, 20.0, 40.0])
+        XCTAssertNotNil(features)
+        // p25 = 0.25 * 4 = index 1.0 = 20.0
+        XCTAssertEqual(features!.percentile25, 17.5, accuracy: 0.01)
+        // p75 = 0.75 * 4 = index 3.0 = 40.0
+        XCTAssertEqual(features!.percentile75, 42.5, accuracy: 0.01)
+    }
+
+    func testPercentileEmptyReturnsNil() {
+        XCTAssertNil(StatisticalFeatures.from([]))
+    }
+
+    func testMedianEvenCount() {
+        // sorted: [1, 2, 3, 4] → median = (2+3)/2 = 2.5
+        let features = StatisticalFeatures.from([3.0, 1.0, 4.0, 2.0])
+        XCTAssertNotNil(features)
+        XCTAssertEqual(features!.median, 2.5, accuracy: 0.001)
+    }
+
+    func testMedianOddCount() {
+        // sorted: [1, 2, 3] → median = 2
+        let features = StatisticalFeatures.from([3.0, 1.0, 2.0])
+        XCTAssertNotNil(features)
+        XCTAssertEqual(features!.median, 2.0, accuracy: 0.001)
+    }
+
+    func testMeanAndStdDev() {
+        let features = StatisticalFeatures.from([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
+        XCTAssertNotNil(features)
+        XCTAssertEqual(features!.mean, 5.0, accuracy: 0.001)
+        XCTAssertEqual(features!.stdDev, 2.0, accuracy: 0.001)
+    }
+
+    func testCoefficientOfVariationZeroMean() {
+        // mean=0 → cv should be 0, not NaN
+        let features = StatisticalFeatures.from([0.0, 0.0, 0.0])
+        XCTAssertNotNil(features)
+        XCTAssertFalse(features!.coefficientOfVariation.isNaN)
+        XCTAssertEqual(features!.coefficientOfVariation, 0.0)
+    }
+
+    func testIQRCalculation() {
+        let features = StatisticalFeatures.from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+        XCTAssertNotNil(features)
+        // IQR = p75 - p25, should be positive
+        XCTAssertGreaterThan(features!.iqr, 0)
+        XCTAssertEqual(features!.iqr, features!.percentile75 - features!.percentile25, accuracy: 0.001)
+    }
+}
+
+// MARK: - TemporalFeatures Regression Slope Tests
+
+final class TemporalFeaturesRegressionTests: XCTestCase {
+
+    private func makeSnapshot(deviceID: String = "dev1", score: Double, offset: TimeInterval) -> DeviceDetectionSnapshot {
+        DeviceDetectionSnapshot(
+            timestamp: Date().timeIntervalSince1970 - offset,
+            deviceID: deviceID,
+            riskScore: score,
+            isHighRisk: score >= 60,
+            jailbreakStatus: JailbreakStatus(isJailbroken: false, confidence: 0.1, detectedMethods: []),
+            isVPNActive: false,
+            isProxyEnabled: false,
+            networkInterfaceType: "wifi"
+        )
+    }
+
+    /// All scores identical → denominator = 0 → should return .stable
+    func testRegressionDenominatorZeroReturnStable() {
+        // Build a calculator with snapshots that all have the same score
+        let history = DeviceHistory.shared
+        let deviceID = "test_regression_stable_\(UUID().uuidString)"
+        for i in 0..<5 {
+            let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: TimeInterval(i * 3600))
+            history.addSnapshot(snap)
+        }
+        let calculator = TemporalFeaturesCalculator(history: history)
+        let features = calculator.calculate(for: deviceID)
+        // Flat line → stable
+        XCTAssertEqual(features.riskTrend, .stable)
+    }
+
+    /// Monotonically increasing scores → deteriorating
+    func testRegressionIncreasingScoresDeteriorate() {
+        let history = DeviceHistory.shared
+        let deviceID = "test_regression_increase_\(UUID().uuidString)"
+        let scores = [10.0, 25.0, 40.0, 55.0, 70.0, 85.0]
+        for (i, score) in scores.enumerated() {
+            let snap = makeSnapshot(deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
+            history.addSnapshot(snap)
+        }
+        let calculator = TemporalFeaturesCalculator(history: history)
+        let features = calculator.calculate(for: deviceID)
+        XCTAssertEqual(features.riskTrend, .deteriorating)
+    }
+
+    /// Monotonically decreasing scores → improving
+    func testRegressionDecreasingScoresImprove() {
+        let history = DeviceHistory.shared
+        let deviceID = "test_regression_decrease_\(UUID().uuidString)"
+        let scores = [85.0, 70.0, 55.0, 40.0, 25.0, 10.0]
+        for (i, score) in scores.enumerated() {
+            let snap = makeSnapshot(deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
+            history.addSnapshot(snap)
+        }
+        let calculator = TemporalFeaturesCalculator(history: history)
+        let features = calculator.calculate(for: deviceID)
+        XCTAssertEqual(features.riskTrend, .improving)
+    }
+
+    /// Fewer than 3 snapshots → unknown
+    func testRegressionInsufficientDataReturnsUnknown() {
+        let history = DeviceHistory.shared
+        let deviceID = "test_regression_unknown_\(UUID().uuidString)"
+        let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: 0)
+        history.addSnapshot(snap)
+        let calculator = TemporalFeaturesCalculator(history: history)
+        let features = calculator.calculate(for: deviceID)
+        XCTAssertEqual(features.riskTrend, .unknown)
+    }
+}

--- a/cprisk-armor/Sources/SymbolStripper/SymbolStripper.swift
+++ b/cprisk-armor/Sources/SymbolStripper/SymbolStripper.swift
@@ -85,6 +85,6 @@ public final class SymbolStripperPass: ArmorPass {
     private static let hexTable: [UInt8] = Array("0123456789abcdef".utf8)
 
     private static func randomHexBytes(count: Int) -> Data {
-        Data((0..<count).map { _ in hexTable[Int.random(in: 0..<16)] })
+        Data((0..<count).map { _ in hexTable[Int.random(in: 0..<hexTable.count)] })
     }
 }


### PR DESCRIPTION
Bug 修复:
- TemporalFeatures: 线性回归斜率计算分母为零时 guard return .stable， 防止 slope = NaN/Inf 污染趋势判断
- AnomalyDetector: IQR 四分位数改用线性插值（同 numpy percentile linear）， 并新增 interpolatedPercentile 私有辅助函数，结果与统计标准一致
- BehaviorBaseline: percentile() 越界回退值从 sorted[0] 改为 0， 消除空数组场景下的潜在越界崩溃
- DeviceHistory: freshness 回滚检测条件从 || 改为 &&， 避免合法时钟调整导致历史数据被错误全量清除
- UploadPolicy: jitter 随机因子从 -1...1 收窄为 -0.5...0.5， 确保抖动量不超过延迟本身的一半
- SymbolStripper: randomHexBytes 中魔法数字 16 改为 hexTable.count， 提升可维护性

新增测试:
- AnalysisAndUploadPolicyTests.swift（新文件）： 覆盖 UploadPolicy（风险分级/延迟边界/批量判断）、 AnomalyDetector（Z-score/IQR 含插值正确性验证）、 StatisticalFeatures/BehaviorBaseline（percentile/median/mean/cv）、 TemporalFeatures 线性回归（stable/deteriorating/improving/unknown）
- RiskReportMapperTests: 补充 graphPayload 字段映射回归测试， 验证 commit 54881e1 的 PayloadMirror→DTO 修复有效
