### PR TITLE
fix: 三轮全量审查 — DecisionTree NaN 误放行修复 + 新模块测试补全

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/DecisionTree.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/DecisionTree.swift
@@ -392,6 +392,8 @@ public struct DecisionTree: Codable, Sendable {
     public func decide(context: EvaluationContext) -> RiskAction {
         switch evaluate(context: context) {
         case .next, .branch:
+            // 非有限分数（NaN/Infinity）直接阻断，防止 NaN 比较全部为 false 导致误放行
+            guard context.score.isFinite else { return .block }
             if context.score >= context.policy.criticalThreshold {
                 return .block
             } else if context.score >= context.policy.highThreshold {

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/DecisionTreeTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/DecisionTreeTests.swift
@@ -364,4 +364,46 @@ final class DecisionTreeTests: XCTestCase {
         let decoded = try JSONDecoder().decode(DecisionTree.self, from: data)
         XCTAssertEqual(decoded.name, tree.name)
     }
+
+    // MARK: - NaN score guard (regression: decide() fallback previously returned .allow for NaN)
+
+    func testDecideWithNaNScoreFallbackReturnsBlock() {
+        // Build a tree whose root always returns .next (condition false, no falseBranch)
+        // so the fallback path in decide() is exercised.
+        let tree = DecisionTree(
+            name: "nan_test_tree",
+            root: .condition(ConditionNode(
+                id: "always_false",
+                condition: .custom("never"),
+                trueBranch: .action(ActionNode(id: "unreachable", action: .allow, reason: "unreachable"))
+                // falseBranch intentionally nil → evaluate() returns .next
+            ))
+        )
+        let policy = ScenarioPolicy(mediumThreshold: 30, highThreshold: 55, criticalThreshold: 80)
+        let nanCtx = makeEvalContext(score: Double.nan, policy: policy)
+
+        // Pre-fix: NaN >= any threshold → false → fell through to .allow (security bypass)
+        // Post-fix: NaN guarded → .block
+        XCTAssertEqual(tree.decide(context: nanCtx), .block,
+            "NaN 评分应触发阻断而非误放行")
+    }
+
+    func testDecideWithInfinityScoreReturnsBlock() {
+        let tree = DecisionTree(
+            name: "inf_test_tree",
+            root: .condition(ConditionNode(
+                id: "always_false",
+                condition: .custom("never"),
+                trueBranch: .action(ActionNode(id: "unreachable", action: .allow, reason: "unreachable"))
+            ))
+        )
+        let policy = ScenarioPolicy(mediumThreshold: 30, highThreshold: 55, criticalThreshold: 80)
+        let infCtx = makeEvalContext(score: Double.infinity, policy: policy)
+        // Double.infinity >= any threshold → true, so falls into .block via criticalThreshold check anyway.
+        // But isFinite guard also handles -infinity (which would otherwise slip to .allow).
+        let negInfCtx = makeEvalContext(score: -Double.infinity, policy: policy)
+        XCTAssertEqual(tree.decide(context: infCtx), .block)
+        XCTAssertEqual(tree.decide(context: negInfCtx), .block,
+            "-Infinity 评分应被 isFinite 守卫阻断")
+    }
 }

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/TemporalAnalyzerAndConfigTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/TemporalAnalyzerAndConfigTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import CloudPhoneRiskKit
+
+// MARK: - TimeWindow Tests
+
+final class TimeWindowTests: XCTestCase {
+
+    func testLastHourWindowContainsRecentTimestamp() {
+        let now = Date().timeIntervalSince1970
+        let window = TimeWindow.last1Hour
+        XCTAssertTrue(window.contains(now - 100), "1 小时内的时间戳应在窗口内")
+        XCTAssertFalse(window.contains(now - 7200), "2 小时前的时间戳不应在窗口内")
+    }
+
+    func testExplicitWindowBounds() {
+        let now = Date().timeIntervalSince1970
+        let window = TimeWindow(duration: 3600, startTime: now - 3600, endTime: now)
+        XCTAssertTrue(window.contains(now - 1800))
+        XCTAssertFalse(window.contains(now + 1))
+    }
+
+    func testPresetWindowDurations() {
+        XCTAssertEqual(TimeWindow.last1Hour.duration, 3600)
+        XCTAssertEqual(TimeWindow.last6Hours.duration, 21600)
+        XCTAssertEqual(TimeWindow.last24Hours.duration, 86400)
+        XCTAssertEqual(TimeWindow.last7Days.duration, 604800)
+        XCTAssertEqual(TimeWindow.last30Days.duration, 2592000)
+    }
+
+    func testGetActualRangeEndIsNow() {
+        let window = TimeWindow.last1Hour
+        let range = window.getActualRange()
+        let now = Date().timeIntervalSince1970
+        XCTAssertEqual(range.end, now, accuracy: 1.0, "end 应近似为当前时间")
+        XCTAssertEqual(range.start, range.end - 3600, accuracy: 1.0)
+    }
+}
+
+// MARK: - TemporalRiskHistoryEvent / [TemporalRiskHistoryEvent] Tests
+
+final class TemporalRiskHistoryEventTests: XCTestCase {
+
+    private func makeEvent(
+        timestamp: TimeInterval,
+        score: Double,
+        isHighRisk: Bool = false
+    ) -> TemporalRiskHistoryEvent {
+        TemporalRiskHistoryEvent(
+            timestamp: timestamp,
+            score: score,
+            isHighRisk: isHighRisk,
+            summary: isHighRisk ? "high_risk" : "low_risk"
+        )
+    }
+
+    // MARK: calculateIntervals
+
+    func testCalculateIntervalsEmptyReturnsEmpty() {
+        let events: [TemporalRiskHistoryEvent] = []
+        XCTAssertTrue(events.calculateIntervals().isEmpty)
+    }
+
+    func testCalculateIntervalsSingleEventReturnsEmpty() {
+        let events = [makeEvent(timestamp: 1000, score: 30)]
+        XCTAssertTrue(events.calculateIntervals().isEmpty)
+    }
+
+    func testCalculateIntervalsCorrectDeltas() {
+        let events = [
+            makeEvent(timestamp: 1000, score: 20),
+            makeEvent(timestamp: 1300, score: 25),
+            makeEvent(timestamp: 1900, score: 30)
+        ]
+        let intervals = events.calculateIntervals()
+        XCTAssertEqual(intervals.count, 2)
+        XCTAssertEqual(intervals[0], 300.0, accuracy: 0.001)
+        XCTAssertEqual(intervals[1], 600.0, accuracy: 0.001)
+    }
+
+    func testCalculateIntervalsUnorderedInputSortedFirst() {
+        // Events added out-of-order — should still calculate correct chronological intervals
+        let events = [
+            makeEvent(timestamp: 1900, score: 30),
+            makeEvent(timestamp: 1000, score: 20),
+            makeEvent(timestamp: 1300, score: 25)
+        ]
+        let intervals = events.calculateIntervals()
+        XCTAssertEqual(intervals.count, 2)
+        XCTAssertEqual(intervals[0], 300.0, accuracy: 0.001)
+        XCTAssertEqual(intervals[1], 600.0, accuracy: 0.001)
+    }
+
+    // MARK: averageInterval
+
+    func testAverageIntervalNilForSingleEvent() {
+        let events = [makeEvent(timestamp: 1000, score: 30)]
+        XCTAssertNil(events.averageInterval())
+    }
+
+    func testAverageIntervalNilForEmptyEvents() {
+        let events: [TemporalRiskHistoryEvent] = []
+        XCTAssertNil(events.averageInterval())
+    }
+
+    func testAverageIntervalCorrectValue() {
+        let events = [
+            makeEvent(timestamp: 0, score: 10),
+            makeEvent(timestamp: 100, score: 20),
+            makeEvent(timestamp: 300, score: 30)
+        ]
+        // Intervals: [100, 200] → avg = 150
+        let avg = events.averageInterval()
+        XCTAssertNotNil(avg)
+        XCTAssertEqual(avg!, 150.0, accuracy: 0.001)
+    }
+
+    // MARK: sortedByTime
+
+    func testSortedByTimeAscending() {
+        let events = [
+            makeEvent(timestamp: 300, score: 30),
+            makeEvent(timestamp: 100, score: 10),
+            makeEvent(timestamp: 200, score: 20)
+        ]
+        let sorted = events.sortedByTime()
+        XCTAssertEqual(sorted[0].timestamp, 100)
+        XCTAssertEqual(sorted[1].timestamp, 200)
+        XCTAssertEqual(sorted[2].timestamp, 300)
+    }
+
+    // MARK: filtered(by:)
+
+    func testFilteredByWindowKeepsInWindow() {
+        let now = Date().timeIntervalSince1970
+        let events = [
+            makeEvent(timestamp: now - 500, score: 20),
+            makeEvent(timestamp: now - 200, score: 25),
+            makeEvent(timestamp: now - 10000, score: 80, isHighRisk: true)
+        ]
+        let filtered = events.filtered(by: .last1Hour)
+        XCTAssertEqual(filtered.count, 2, "超出 1 小时的事件应被过滤")
+    }
+
+    // MARK: Codable round-trip
+
+    func testTemporalRiskHistoryEventCodableRoundtrip() throws {
+        let event = TemporalRiskHistoryEvent(
+            timestamp: 1741800000,
+            score: 72.5,
+            isHighRisk: true,
+            summary: "high_risk",
+            scenario: .payment,
+            action: .block,
+            extras: ["source": "jailbreak"]
+        )
+        let data = try JSONEncoder().encode(event)
+        let decoded = try JSONDecoder().decode(TemporalRiskHistoryEvent.self, from: data)
+        XCTAssertEqual(decoded.timestamp, event.timestamp, accuracy: 0.001)
+        XCTAssertEqual(decoded.score, event.score, accuracy: 0.001)
+        XCTAssertEqual(decoded.isHighRisk, event.isHighRisk)
+        XCTAssertEqual(decoded.summary, event.summary)
+        XCTAssertEqual(decoded.scenario, event.scenario)
+        XCTAssertEqual(decoded.action, event.action)
+        XCTAssertEqual(decoded.extras["source"], "jailbreak")
+    }
+}
+
+// MARK: - ProviderConfig Tests
+
+final class ProviderConfigTests: XCTestCase {
+
+    private func makeConfig(
+        effectiveDaysAgo: Double = 1,
+        expireDaysFromNow: Double = 30
+    ) -> ProviderConfig {
+        let now = Date()
+        return ProviderConfig(
+            version: "1.0.0",
+            effectiveTime: now.addingTimeInterval(-effectiveDaysAgo * 86400),
+            expireTime: now.addingTimeInterval(expireDaysFromNow * 86400),
+            detectors: ProviderDetectorConfigs(),
+            policies: PolicyConfigs(),
+            scenarios: ScenarioConfigs(),
+            signature: "test_sig"
+        )
+    }
+
+    func testEffectiveConfigIsEffectiveAndNotExpired() {
+        let config = makeConfig()
+        XCTAssertTrue(config.isEffective)
+        XCTAssertFalse(config.isExpired)
+    }
+
+    func testExpiredConfigIsNotEffective() {
+        let config = makeConfig(expireDaysFromNow: -1)
+        XCTAssertFalse(config.isEffective, "已过期配置不应为 effective")
+        XCTAssertTrue(config.isExpired)
+    }
+
+    func testFutureEffectiveTimeConfigIsNotYetEffective() {
+        let config = makeConfig(effectiveDaysAgo: -1, expireDaysFromNow: 30) // effective in 1 day
+        XCTAssertFalse(config.isEffective, "尚未生效的配置不应为 effective")
+        XCTAssertFalse(config.isExpired)
+    }
+
+    func testCodableRoundtrip() throws {
+        let config = makeConfig()
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ProviderConfig.self, from: data)
+        XCTAssertEqual(decoded.version, config.version)
+        XCTAssertEqual(decoded.signature, config.signature)
+    }
+}


### PR DESCRIPTION
Bug 修复:
- DecisionTree.decide(): fallback 路径（.next/.branch）对 NaN/−Infinity 评分缺少有限性守卫，导致所有比较均为 false 而误放行（返回 .allow）； 在 fallback 入口新增 guard context.score.isFinite else { return .block }， 与 ScoreActionNode 的同类守卫（line 284）保持一致

新增测试:
- DecisionTreeTests（扩展，2 个用例）： testDecideWithNaNScoreFallbackReturnsBlock — 验证 NaN 评分在 fallback 路径触发 .block 而非 .allow（此前的安全漏洞回归测试）； testDecideWithInfinityScoreFallbackReturnsBlock — 验证 ±Infinity 处理

- TemporalAnalyzerAndConfigTests.swift（新文件，17 个用例）： TimeWindowTests (4) — 预定义窗口、显式边界、getActualRange; TemporalRiskHistoryEventTests (9) — calculateIntervals 空/单/多值/乱序、 averageInterval、sortedByTime、filtered(by:)、Codable 往返； ProviderConfigTests (4) — isEffective/isExpired 正常/已过期/尚未生效、 Codable 往返

