### PR TITLE
fix: 修复 validateFileStat 运算符优先级 bug

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
@@ -371,7 +371,7 @@ struct DualPathValidator {
             || (secureAccessExists != nil && secureAccessExists != stdAccessExists)
         let tampered = secureUnavailableButStdHasValue || mismatchWhenBothAvailable
         if tampered { LibcPrologueGuard.invalidateCache() }
-        let exists = secureAccessExists ?? stdAccessExists || fileManagerExists
+        let exists = (secureAccessExists ?? stdAccessExists) || fileManagerExists
         return (exists, tampered, bypassed, traced, hooked)
     }
 }


### PR DESCRIPTION
Swift 中 `||` 优先级高于 `??`，导致
  secureAccessExists ?? stdAccessExists || fileManagerExists
被解析为
  secureAccessExists ?? (stdAccessExists || fileManagerExists)

当 secureAccessExists = false 且 fileManagerExists = true 时， 错误版本返回 false（漏报），正确版本应返回 true。
加括号修正为 (secureAccessExists ?? stdAccessExists) || fileManagerExists。

