### PR TITLE
Resolve storage directory with fallbacks for reports and device history; add tests

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskAppCore/RiskReportStorage.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskAppCore/RiskReportStorage.swift
@@ -2,100 +2,121 @@ import CloudPhoneRiskKit
 import Foundation
 
 public struct StoredRiskReport: Sendable, Hashable {
-    public var path: String
-    public var filename: String
-    public var modifiedAt: Date?
-    public var bytes: Int64
-    public var isEncrypted: Bool
+  public var path: String
+  public var filename: String
+  public var modifiedAt: Date?
+  public var bytes: Int64
+  public var isEncrypted: Bool
 }
 
 /// 检测 App 的“报告存储层”：负责列举/读取/清空本地报告文件。
 public enum RiskReportStorage {
-    public static func reportsDirectoryURL() throws -> URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        guard let base else {
-            throw NSError(domain: "CloudPhoneRiskAppCore", code: 1, userInfo: [NSLocalizedDescriptionKey: "applicationSupportDirectory unavailable"])
-        }
-        return base.appendingPathComponent("CloudPhoneRiskKit/reports", isDirectory: true)
+  static func resolveBaseDirectory(
+    applicationSupportDirectories: [URL],
+    cachesDirectories: [URL],
+    temporaryDirectory: URL
+  ) -> URL {
+    if let applicationSupportDirectory = applicationSupportDirectories.first {
+      return applicationSupportDirectory
+    }
+    if let cachesDirectory = cachesDirectories.first {
+      return cachesDirectory.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true)
+    }
+    return temporaryDirectory.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true)
+  }
+
+  public static func reportsDirectoryURL() throws -> URL {
+    let fileManager = FileManager.default
+    let base = resolveBaseDirectory(
+      applicationSupportDirectories: fileManager.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask),
+      cachesDirectories: fileManager.urls(for: .cachesDirectory, in: .userDomainMask),
+      temporaryDirectory: fileManager.temporaryDirectory
+    )
+    return base.appendingPathComponent("reports", isDirectory: true)
+  }
+
+  public static func list() -> [StoredRiskReport] {
+    guard let dir = try? reportsDirectoryURL() else { return [] }
+    return list(in: dir)
+  }
+
+  public static func list(in dir: URL) -> [StoredRiskReport] {
+    let fm = FileManager.default
+    guard
+      let items = try? fm.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
+        options: [.skipsHiddenFiles]
+      )
+    else { return [] }
+
+    let out: [StoredRiskReport] = items.compactMap { url in
+      let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+      let bytes = Int64(values?.fileSize ?? 0)
+      let name = url.lastPathComponent
+      if name.hasSuffix(".meta.json") { return nil }
+      return StoredRiskReport(
+        path: url.path,
+        filename: name,
+        modifiedAt: values?.contentModificationDate,
+        bytes: bytes,
+        isEncrypted: !name.hasSuffix(".json")
+      )
     }
 
-    public static func list() -> [StoredRiskReport] {
-        guard let dir = try? reportsDirectoryURL() else { return [] }
-        return list(in: dir)
+    return out.sorted { (a, b) in
+      let ad = a.modifiedAt ?? .distantPast
+      let bd = b.modifiedAt ?? .distantPast
+      return ad > bd
     }
+  }
 
-    public static func list(in dir: URL) -> [StoredRiskReport] {
-        let fm = FileManager.default
-        guard let items = try? fm.contentsOfDirectory(
-            at: dir,
-            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
-            options: [.skipsHiddenFiles]
-        ) else { return [] }
+  public static func loadJSONString(atPath path: String) -> String? {
+    #if os(iOS)
+      return CPRiskStore.shared.decryptReport(atPath: path, error: nil)
+    #else
+      guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+      return String(data: data, encoding: .utf8)
+    #endif
+  }
 
-        let out: [StoredRiskReport] = items.compactMap { url in
-            let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
-            let bytes = Int64(values?.fileSize ?? 0)
-            let name = url.lastPathComponent
-            if name.hasSuffix(".meta.json") { return nil }
-            return StoredRiskReport(
-                path: url.path,
-                filename: name,
-                modifiedAt: values?.contentModificationDate,
-                bytes: bytes,
-                isEncrypted: !name.hasSuffix(".json")
-            )
-        }
+  public static func loadDTO(atPath path: String) -> RiskReportDTO? {
+    guard let json = loadJSONString(atPath: path) else { return nil }
+    guard let data = json.data(using: .utf8) else { return nil }
+    return RiskReportMapper.dto(from: data)
+  }
 
-        return out.sorted { (a, b) in
-            let ad = a.modifiedAt ?? .distantPast
-            let bd = b.modifiedAt ?? .distantPast
-            return ad > bd
-        }
+  public static func listSummaries() -> [(report: StoredRiskReport, summary: RiskReportSummary?)] {
+    guard let dir = try? reportsDirectoryURL() else { return [] }
+    return listSummaries(in: dir)
+  }
+
+  public static func listSummaries(in dir: URL) -> [(
+    report: StoredRiskReport, summary: RiskReportSummary?
+  )] {
+    let reports = list(in: dir)
+    return reports.map { r in
+      if let meta = RiskReportSummaryIO.readMeta(reportPath: r.path) {
+        return (r, meta)
+      }
+      guard let dto = loadDTO(atPath: r.path) else { return (r, nil) }
+      RiskReportSummaryIO.writeMeta(for: dto, reportPath: r.path)
+      let summary = RiskReportSummaryIO.readMeta(reportPath: r.path)
+      return (r, summary)
     }
+  }
 
-    public static func loadJSONString(atPath path: String) -> String? {
-#if os(iOS)
-        return CPRiskStore.shared.decryptReport(atPath: path, error: nil)
-#else
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
-        return String(data: data, encoding: .utf8)
-#endif
-    }
+  public static func delete(atPath path: String) -> Bool {
+    let meta = RiskReportSummaryIO.metaPath(forReportPath: path)
+    _ = try? FileManager.default.removeItem(atPath: meta)
+    return (try? FileManager.default.removeItem(atPath: path)) != nil
+  }
 
-    public static func loadDTO(atPath path: String) -> RiskReportDTO? {
-        guard let json = loadJSONString(atPath: path) else { return nil }
-        guard let data = json.data(using: .utf8) else { return nil }
-        return RiskReportMapper.dto(from: data)
+  public static func deleteAll() {
+    let items = list()
+    for i in items {
+      _ = delete(atPath: i.path)
     }
-
-    public static func listSummaries() -> [(report: StoredRiskReport, summary: RiskReportSummary?)] {
-        guard let dir = try? reportsDirectoryURL() else { return [] }
-        return listSummaries(in: dir)
-    }
-
-    public static func listSummaries(in dir: URL) -> [(report: StoredRiskReport, summary: RiskReportSummary?)] {
-        let reports = list(in: dir)
-        return reports.map { r in
-            if let meta = RiskReportSummaryIO.readMeta(reportPath: r.path) {
-                return (r, meta)
-            }
-            guard let dto = loadDTO(atPath: r.path) else { return (r, nil) }
-            RiskReportSummaryIO.writeMeta(for: dto, reportPath: r.path)
-            let summary = RiskReportSummaryIO.readMeta(reportPath: r.path)
-            return (r, summary)
-        }
-    }
-
-    public static func delete(atPath path: String) -> Bool {
-        let meta = RiskReportSummaryIO.metaPath(forReportPath: path)
-        _ = try? FileManager.default.removeItem(atPath: meta)
-        return (try? FileManager.default.removeItem(atPath: path)) != nil
-    }
-
-    public static func deleteAll() {
-        let items = list()
-        for i in items {
-            _ = delete(atPath: i.path)
-        }
-    }
+  }
 }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/DeviceHistory.swift
@@ -3,608 +3,652 @@ import Foundation
 // MARK: - 设备检测快照
 /// 单次检测的完整快照，包含所有检测信号
 public struct DeviceDetectionSnapshot: Codable, Sendable {
-    /// 检测时间戳
-    public var timestamp: TimeInterval
+  /// 检测时间戳
+  public var timestamp: TimeInterval
 
-    /// 设备 ID
-    public var deviceID: String
+  /// 设备 ID
+  public var deviceID: String
 
-    /// 风险分数
-    public var riskScore: Double
+  /// 风险分数
+  public var riskScore: Double
 
-    /// 是否高风险
-    public var isHighRisk: Bool
+  /// 是否高风险
+  public var isHighRisk: Bool
 
-    /// 越狱检测结果
-    public var jailbreakStatus: JailbreakStatus
+  /// 越狱检测结果
+  public var jailbreakStatus: JailbreakStatus
 
-    /// VPN 是否激活
-    public var isVPNActive: Bool
+  /// VPN 是否激活
+  public var isVPNActive: Bool
 
-    /// 代理是否启用
-    public var isProxyEnabled: Bool
+  /// 代理是否启用
+  public var isProxyEnabled: Bool
 
-    /// 行为信号摘要
-    public var behaviorSummary: BehaviorSummary?
+  /// 行为信号摘要
+  public var behaviorSummary: BehaviorSummary?
 
-    /// 网络接口类型
-    public var networkInterfaceType: String
+  /// 网络接口类型
+  public var networkInterfaceType: String
 
-    private enum CodingKeys: String, CodingKey {
-        case timestamp = "ts"
-        case deviceID = "di"
-        case riskScore = "rs"
-        case isHighRisk = "hr"
-        case jailbreakStatus = "js"
-        case isVPNActive = "va"
-        case isProxyEnabled = "pe"
-        case behaviorSummary = "bs"
-        case networkInterfaceType = "ni"
-    }
+  private enum CodingKeys: String, CodingKey {
+    case timestamp = "ts"
+    case deviceID = "di"
+    case riskScore = "rs"
+    case isHighRisk = "hr"
+    case jailbreakStatus = "js"
+    case isVPNActive = "va"
+    case isProxyEnabled = "pe"
+    case behaviorSummary = "bs"
+    case networkInterfaceType = "ni"
+  }
 
-    public init(
-        timestamp: TimeInterval,
-        deviceID: String,
-        riskScore: Double,
-        isHighRisk: Bool,
-        jailbreakStatus: JailbreakStatus,
-        isVPNActive: Bool,
-        isProxyEnabled: Bool,
-        behaviorSummary: BehaviorSummary? = nil,
-        networkInterfaceType: String
-    ) {
-        self.timestamp = timestamp
-        self.deviceID = deviceID
-        self.riskScore = riskScore
-        self.isHighRisk = isHighRisk
-        self.jailbreakStatus = jailbreakStatus
-        self.isVPNActive = isVPNActive
-        self.isProxyEnabled = isProxyEnabled
-        self.behaviorSummary = behaviorSummary
-        self.networkInterfaceType = networkInterfaceType
-    }
+  public init(
+    timestamp: TimeInterval,
+    deviceID: String,
+    riskScore: Double,
+    isHighRisk: Bool,
+    jailbreakStatus: JailbreakStatus,
+    isVPNActive: Bool,
+    isProxyEnabled: Bool,
+    behaviorSummary: BehaviorSummary? = nil,
+    networkInterfaceType: String
+  ) {
+    self.timestamp = timestamp
+    self.deviceID = deviceID
+    self.riskScore = riskScore
+    self.isHighRisk = isHighRisk
+    self.jailbreakStatus = jailbreakStatus
+    self.isVPNActive = isVPNActive
+    self.isProxyEnabled = isProxyEnabled
+    self.behaviorSummary = behaviorSummary
+    self.networkInterfaceType = networkInterfaceType
+  }
 
-    /// 从 RiskSnapshot 和 RiskScoreReport 创建快照
-    public static func from(snapshot: RiskSnapshot, report: RiskScoreReport) -> DeviceDetectionSnapshot {
-        let now = Date().timeIntervalSince1970
+  /// 从 RiskSnapshot 和 RiskScoreReport 创建快照
+  public static func from(snapshot: RiskSnapshot, report: RiskScoreReport)
+    -> DeviceDetectionSnapshot
+  {
+    let now = Date().timeIntervalSince1970
 
-        return DeviceDetectionSnapshot(
-            timestamp: now,
-            deviceID: snapshot.deviceID,
-            riskScore: report.score,
-            isHighRisk: report.isHighRisk,
-            jailbreakStatus: JailbreakStatus(
-                isJailbroken: snapshot.jailbreak.isJailbroken,
-                confidence: snapshot.jailbreak.confidence,
-                detectedMethods: snapshot.jailbreak.detectedMethods
-            ),
-            isVPNActive: snapshot.network.isVPNActive,
-            isProxyEnabled: snapshot.network.proxyEnabled,
-            behaviorSummary: BehaviorSummary(from: snapshot.behavior),
-            networkInterfaceType: snapshot.network.interfaceType.value
-        )
-    }
+    return DeviceDetectionSnapshot(
+      timestamp: now,
+      deviceID: snapshot.deviceID,
+      riskScore: report.score,
+      isHighRisk: report.isHighRisk,
+      jailbreakStatus: JailbreakStatus(
+        isJailbroken: snapshot.jailbreak.isJailbroken,
+        confidence: snapshot.jailbreak.confidence,
+        detectedMethods: snapshot.jailbreak.detectedMethods
+      ),
+      isVPNActive: snapshot.network.isVPNActive,
+      isProxyEnabled: snapshot.network.proxyEnabled,
+      behaviorSummary: BehaviorSummary(from: snapshot.behavior),
+      networkInterfaceType: snapshot.network.interfaceType.value
+    )
+  }
 }
 
 // MARK: - 越狱状态摘要
 public struct JailbreakStatus: Codable, Sendable {
-    public var isJailbroken: Bool
-    public var confidence: Double
-    public var detectedMethods: [String]
+  public var isJailbroken: Bool
+  public var confidence: Double
+  public var detectedMethods: [String]
 
-    private enum CodingKeys: String, CodingKey {
-        case isJailbroken = "ij"
-        case confidence = "c"
-        case detectedMethods = "dm"
-    }
+  private enum CodingKeys: String, CodingKey {
+    case isJailbroken = "ij"
+    case confidence = "c"
+    case detectedMethods = "dm"
+  }
 
-    public init(isJailbroken: Bool, confidence: Double, detectedMethods: [String]) {
-        self.isJailbroken = isJailbroken
-        self.confidence = confidence
-        self.detectedMethods = detectedMethods
-    }
+  public init(isJailbroken: Bool, confidence: Double, detectedMethods: [String]) {
+    self.isJailbroken = isJailbroken
+    self.confidence = confidence
+    self.detectedMethods = detectedMethods
+  }
 }
 
 // MARK: - 行为摘要
 public struct BehaviorSummary: Codable, Sendable {
-    public var touchSampleCount: Int
-    public var tapCount: Int
-    public var swipeCount: Int
-    public var motionSampleCount: Int
-    public var actionCount: Int
-    public var touchMotionCorrelation: Double?
+  public var touchSampleCount: Int
+  public var tapCount: Int
+  public var swipeCount: Int
+  public var motionSampleCount: Int
+  public var actionCount: Int
+  public var touchMotionCorrelation: Double?
 
-    private enum CodingKeys: String, CodingKey {
-        case touchSampleCount = "tc"
-        case tapCount = "tp"
-        case swipeCount = "sw"
-        case motionSampleCount = "ms"
-        case actionCount = "ac"
-        case touchMotionCorrelation = "tm"
-    }
+  private enum CodingKeys: String, CodingKey {
+    case touchSampleCount = "tc"
+    case tapCount = "tp"
+    case swipeCount = "sw"
+    case motionSampleCount = "ms"
+    case actionCount = "ac"
+    case touchMotionCorrelation = "tm"
+  }
 
-    public init(from signals: BehaviorSignals) {
-        self.touchSampleCount = signals.touch.sampleCount
-        self.tapCount = signals.touch.tapCount
-        self.swipeCount = signals.touch.swipeCount
-        self.motionSampleCount = signals.motion.sampleCount
-        self.actionCount = signals.actionCount
-        self.touchMotionCorrelation = signals.touchMotionCorrelation
-    }
+  public init(from signals: BehaviorSignals) {
+    self.touchSampleCount = signals.touch.sampleCount
+    self.tapCount = signals.touch.tapCount
+    self.swipeCount = signals.touch.swipeCount
+    self.motionSampleCount = signals.motion.sampleCount
+    self.actionCount = signals.actionCount
+    self.touchMotionCorrelation = signals.touchMotionCorrelation
+  }
 }
 
 // MARK: - 历史查询结果
 public struct HistoryQueryResult: Sendable {
-    public var snapshots: [DeviceDetectionSnapshot]
-    public var totalCount: Int
-    public var timeRange: (start: TimeInterval, end: TimeInterval)?
+  public var snapshots: [DeviceDetectionSnapshot]
+  public var totalCount: Int
+  public var timeRange: (start: TimeInterval, end: TimeInterval)?
 
-    public init(snapshots: [DeviceDetectionSnapshot], timeRange: (start: TimeInterval, end: TimeInterval)? = nil) {
-        self.snapshots = snapshots
-        self.totalCount = snapshots.count
-        self.timeRange = timeRange
-    }
+  public init(
+    snapshots: [DeviceDetectionSnapshot], timeRange: (start: TimeInterval, end: TimeInterval)? = nil
+  ) {
+    self.snapshots = snapshots
+    self.totalCount = snapshots.count
+    self.timeRange = timeRange
+  }
 }
 
 // MARK: - 设备历史存储
 /// 负责设备检测快照的存储、查询和清理
 public final class DeviceHistory {
-    public static let shared = DeviceHistory()
+  public static let shared = DeviceHistory()
 
-    private struct StoredEnvelope: Codable {
-        var schemaVersion: Int
-        var snapshots: [DeviceDetectionSnapshot]
-        var latestTimestamp: Double
-        var sequence: UInt64
+  private struct StoredEnvelope: Codable {
+    var schemaVersion: Int
+    var snapshots: [DeviceDetectionSnapshot]
+    var latestTimestamp: Double
+    var sequence: UInt64
 
-        private enum CodingKeys: String, CodingKey {
-            case schemaVersion = "sv"
-            case snapshots = "sn"
-            case latestTimestamp = "lt"
-            case sequence = "sq"
-        }
+    private enum CodingKeys: String, CodingKey {
+      case schemaVersion = "sv"
+      case snapshots = "sn"
+      case latestTimestamp = "lt"
+      case sequence = "sq"
+    }
+  }
+
+  private let lock = NSLock()
+  private let fileManager = FileManager.default
+  private let storeURL: URL
+  private let hmacURL: URL
+  private let hmacPurpose = "device_history"
+  private let freshnessAnchor = FreshnessAnchor(account: "device_history_v2_freshness")
+
+  private let maxSnapshots = 500
+
+  /// 快照最大保留时间（30天）
+  private let maxAgeSeconds: TimeInterval = 30 * 24 * 3600
+
+  /// 内存缓存
+  private var cachedSnapshots: [DeviceDetectionSnapshot] = []
+  private var cachedFreshness: FreshnessState = .zero
+
+  /// 缓存是否脏（需要持久化）
+  private var isDirty = false
+
+  private init() {
+    let storageDirectory = Self.resolveStorageDirectory(fileManager: fileManager)
+    do {
+      try fileManager.createDirectory(
+        at: storageDirectory,
+        withIntermediateDirectories: true,
+        attributes: [FileAttributeKey.protectionKey: FileProtectionType.complete]
+      )
+    } catch {
+      Logger.log(
+        "DeviceHistory: failed to create storage directory - \(error.localizedDescription)")
+    }
+    self.storeURL = storageDirectory.appendingPathComponent("cloudphone_device_history_v2.json")
+    self.hmacURL = storageDirectory.appendingPathComponent("cloudphone_device_history_v2.json.hmac")
+    migrateFromDocumentsIfNeeded()
+    loadFromDisk()
+  }
+
+  static func resolveStorageDirectory(
+    applicationSupportDirectories: [URL],
+    cachesDirectories: [URL],
+    temporaryDirectory: URL
+  ) -> URL {
+    if let appSupportDirectory = applicationSupportDirectories.first {
+      return appSupportDirectory
+    }
+    if let cachesDirectory = cachesDirectories.first {
+      Logger.log(
+        "DeviceHistory: applicationSupportDirectory unavailable, falling back to cachesDirectory")
+      return cachesDirectory.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true)
+    }
+    Logger.log(
+      "DeviceHistory: applicationSupportDirectory unavailable, falling back to temporaryDirectory")
+    return temporaryDirectory.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true)
+  }
+
+  private static func resolveStorageDirectory(fileManager: FileManager) -> URL {
+    resolveStorageDirectory(
+      applicationSupportDirectories: fileManager.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask),
+      cachesDirectories: fileManager.urls(for: .cachesDirectory, in: .userDomainMask),
+      temporaryDirectory: fileManager.temporaryDirectory
+    )
+  }
+
+  private func migrateFromDocumentsIfNeeded() {
+    let oldPaths = fileManager.urls(for: .documentDirectory, in: .userDomainMask)
+    guard let docDir = oldPaths.first else { return }
+    let oldStore = docDir.appendingPathComponent("cloudphone_device_history_v1.json")
+    guard fileManager.fileExists(atPath: oldStore.path) else { return }
+    do {
+      try fileManager.removeItem(at: oldStore)
+    } catch {
+      Logger.log("DeviceHistory: failed to remove legacy store - \(error.localizedDescription)")
+    }
+    let oldHmac = docDir.appendingPathComponent("cloudphone_device_history_v1.json.hmac")
+    do {
+      try fileManager.removeItem(at: oldHmac)
+    } catch {
+      Logger.log("DeviceHistory: failed to remove legacy hmac - \(error.localizedDescription)")
+    }
+    Logger.log("DeviceHistory: migrated from Documents to ApplicationSupport")
+  }
+
+  // MARK: - 添加快照
+
+  /// 添加新的检测快照
+  public func addSnapshot(_ snapshot: DeviceDetectionSnapshot) {
+    lock.lock()
+    defer { lock.unlock() }
+
+    cachedSnapshots.append(snapshot)
+    isDirty = true
+
+    // 限制内存中的快照数量
+    if cachedSnapshots.count > maxSnapshots {
+      cachedSnapshots = Array(cachedSnapshots.suffix(maxSnapshots))
     }
 
-    private let lock = NSLock()
-    private let fileManager = FileManager.default
-    private let storeURL: URL
-    private let hmacURL: URL
-    private let hmacPurpose = "device_history"
-    private let freshnessAnchor = FreshnessAnchor(account: "device_history_v2_freshness")
+    // 异步持久化
+    DispatchQueue.global(qos: .utility).async { [weak self] in
+      self?.persistIfDirty()
+    }
+  }
 
-    private let maxSnapshots = 500
+  /// 从 RiskSnapshot 和 RiskScoreReport 创建并添加快照
+  public func addSnapshot(from riskSnapshot: RiskSnapshot, report: RiskScoreReport) {
+    let snapshot = DeviceDetectionSnapshot.from(snapshot: riskSnapshot, report: report)
+    addSnapshot(snapshot)
+  }
 
-    /// 快照最大保留时间（30天）
-    private let maxAgeSeconds: TimeInterval = 30 * 24 * 3600
+  // MARK: - 查询操作
 
-    /// 内存缓存
-    private var cachedSnapshots: [DeviceDetectionSnapshot] = []
-    private var cachedFreshness: FreshnessState = .zero
+  /// 查询所有快照
+  public func getAllSnapshots() -> [DeviceDetectionSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+    return cleanAndReturn()
+  }
 
-    /// 缓存是否脏（需要持久化）
-    private var isDirty = false
+  /// 查询指定时间范围内的快照
+  public func getSnapshots(from startTime: TimeInterval, to endTime: TimeInterval)
+    -> [DeviceDetectionSnapshot]
+  {
+    lock.lock()
+    defer { lock.unlock() }
 
-    private init() {
-        let paths = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-        guard let appSupportDirectory = paths.first else {
-            Logger.log("DeviceHistory: applicationSupportDirectory unavailable")
-            fatalError("DeviceHistory: applicationSupportDirectory unavailable")
-        }
-        do {
-            try fileManager.createDirectory(
-                at: appSupportDirectory,
-                withIntermediateDirectories: true,
-                attributes: [FileAttributeKey.protectionKey: FileProtectionType.complete]
-            )
-        } catch {
-            Logger.log("DeviceHistory: failed to create storage directory - \(error.localizedDescription)")
-        }
-        self.storeURL = appSupportDirectory.appendingPathComponent("cloudphone_device_history_v2.json")
-        self.hmacURL = appSupportDirectory.appendingPathComponent("cloudphone_device_history_v2.json.hmac")
-        migrateFromDocumentsIfNeeded()
-        loadFromDisk()
+    let cleaned = cleanAndReturnLocked()
+    return cleaned.filter { $0.timestamp >= startTime && $0.timestamp <= endTime }
+  }
+
+  /// 查询最近的 N 个快照
+  public func getRecentSnapshots(count: Int) -> [DeviceDetectionSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let cleaned = cleanAndReturnLocked()
+    let recentCount = min(count, cleaned.count)
+    return Array(cleaned.suffix(recentCount))
+  }
+
+  /// 查询指定设备 ID 的快照
+  public func getSnapshots(for deviceID: String) -> [DeviceDetectionSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let cleaned = cleanAndReturnLocked()
+    return cleaned.filter { $0.deviceID == deviceID }
+  }
+
+  /// 查询首次越狱时间
+  public func getFirstJailbreakTime(for deviceID: String? = nil) -> TimeInterval? {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let cleaned = cleanAndReturnLocked()
+    let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
+
+    let jailbrokenSnapshots = filtered.filter { $0.jailbreakStatus.isJailbroken }
+    return jailbrokenSnapshots.map { $0.timestamp }.min()
+  }
+
+  /// 查询最近 N 天内的越狱次数
+  public func getJailbreakCount(days: Int = 7, for deviceID: String? = nil) -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let now = Date().timeIntervalSince1970
+    let startTime = now - TimeInterval(days * 24 * 3600)
+
+    let cleaned = cleanAndReturnLocked()
+    let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
+
+    return filtered.filter { $0.timestamp >= startTime && $0.jailbreakStatus.isJailbroken }.count
+  }
+
+  /// 查询首次出现时间（设备年龄）
+  public func getFirstSeenTime(for deviceID: String) -> TimeInterval? {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let cleaned = cleanAndReturnLocked()
+    let deviceSnapshots = cleaned.filter { $0.deviceID == deviceID }
+    return deviceSnapshots.map { $0.timestamp }.min()
+  }
+
+  /// 获取总检测次数
+  public func getTotalDetectionCount(for deviceID: String) -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let cleaned = cleanAndReturnLocked()
+    return cleaned.filter { $0.deviceID == deviceID }.count
+  }
+
+  /// 获取 VPN 使用频率（最近 N 天）
+  public func getVPNUsageFrequency(days: Int = 7, for deviceID: String? = nil) -> Double {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let now = Date().timeIntervalSince1970
+    let startTime = now - TimeInterval(days * 24 * 3600)
+
+    let cleaned = cleanAndReturnLocked()
+    let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
+    let recentSnapshots = filtered.filter { $0.timestamp >= startTime }
+
+    guard !recentSnapshots.isEmpty else { return 0 }
+
+    let vpnCount = recentSnapshots.filter { $0.isVPNActive }.count
+    return Double(vpnCount) / Double(recentSnapshots.count)
+  }
+
+  /// 获取风险分数历史
+  public func getRiskScoreHistory(days: Int = 30, for deviceID: String? = nil) -> [(
+    timestamp: TimeInterval, score: Double
+  )] {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let now = Date().timeIntervalSince1970
+    let startTime = now - TimeInterval(days * 24 * 3600)
+
+    let cleaned = cleanAndReturnLocked()
+    let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
+    let recentSnapshots = filtered.filter { $0.timestamp >= startTime }
+
+    return
+      recentSnapshots
+      .sorted { $0.timestamp < $1.timestamp }
+      .map { (timestamp: $0.timestamp, score: $0.riskScore) }
+  }
+
+  // MARK: - 数据清理
+
+  /// 执行数据清理，移除过期快照
+  public func cleanup() {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let before = cachedSnapshots.count
+    _ = cleanAndReturnLocked()
+    let after = cachedSnapshots.count
+
+    if before != after {
+      isDirty = true
+      persistIfDirtyLocked()
+    }
+  }
+
+  /// 清空所有历史数据
+  public func clearAll() {
+    lock.lock()
+    defer { lock.unlock() }
+
+    cachedSnapshots.removeAll()
+    cachedFreshness = .zero
+    isDirty = true
+    persistToDiskLocked(resetAnchor: true)
+  }
+
+  // MARK: - 持久化
+
+  private func loadFromDisk() {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let anchor = freshnessAnchor.read() ?? .zero
+    guard fileManager.fileExists(atPath: storeURL.path) else {
+      cachedSnapshots = []
+      cachedFreshness = anchor
+      isDirty = false
+      return
     }
 
-    private func migrateFromDocumentsIfNeeded() {
-        let oldPaths = fileManager.urls(for: .documentDirectory, in: .userDomainMask)
-        guard let docDir = oldPaths.first else { return }
-        let oldStore = docDir.appendingPathComponent("cloudphone_device_history_v1.json")
-        guard fileManager.fileExists(atPath: oldStore.path) else { return }
-        do {
-            try fileManager.removeItem(at: oldStore)
-        } catch {
-            Logger.log("DeviceHistory: failed to remove legacy store - \(error.localizedDescription)")
-        }
-        let oldHmac = docDir.appendingPathComponent("cloudphone_device_history_v1.json.hmac")
-        do {
-            try fileManager.removeItem(at: oldHmac)
-        } catch {
-            Logger.log("DeviceHistory: failed to remove legacy hmac - \(error.localizedDescription)")
-        }
-        Logger.log("DeviceHistory: migrated from Documents to ApplicationSupport")
+    let data: Data
+    do {
+      data = try Data(contentsOf: storeURL)
+    } catch {
+      Logger.log("DeviceHistory: failed to read store file - \(error.localizedDescription)")
+      cachedSnapshots = []
+      cachedFreshness = anchor
+      return
     }
 
-    // MARK: - 添加快照
-
-    /// 添加新的检测快照
-    public func addSnapshot(_ snapshot: DeviceDetectionSnapshot) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        cachedSnapshots.append(snapshot)
-        isDirty = true
-
-        // 限制内存中的快照数量
-        if cachedSnapshots.count > maxSnapshots {
-            cachedSnapshots = Array(cachedSnapshots.suffix(maxSnapshots))
-        }
-
-        // 异步持久化
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            self?.persistIfDirty()
-        }
+    guard let signature = (try? Data(contentsOf: hmacURL)),
+      StorageIntegrityGuard.verify(data, signature: signature, purpose: hmacPurpose)
+    else {
+      clearPersistedFilesLocked(resetAnchor: false)
+      cachedSnapshots = []
+      cachedFreshness = anchor
+      return
     }
 
-    /// 从 RiskSnapshot 和 RiskScoreReport 创建并添加快照
-    public func addSnapshot(from riskSnapshot: RiskSnapshot, report: RiskScoreReport) {
-        let snapshot = DeviceDetectionSnapshot.from(snapshot: riskSnapshot, report: report)
-        addSnapshot(snapshot)
-    }
-
-    // MARK: - 查询操作
-
-    /// 查询所有快照
-    public func getAllSnapshots() -> [DeviceDetectionSnapshot] {
-        lock.lock()
-        defer { lock.unlock() }
-        return cleanAndReturn()
-    }
-
-    /// 查询指定时间范围内的快照
-    public func getSnapshots(from startTime: TimeInterval, to endTime: TimeInterval) -> [DeviceDetectionSnapshot] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        return cleaned.filter { $0.timestamp >= startTime && $0.timestamp <= endTime }
-    }
-
-    /// 查询最近的 N 个快照
-    public func getRecentSnapshots(count: Int) -> [DeviceDetectionSnapshot] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        let recentCount = min(count, cleaned.count)
-        return Array(cleaned.suffix(recentCount))
-    }
-
-    /// 查询指定设备 ID 的快照
-    public func getSnapshots(for deviceID: String) -> [DeviceDetectionSnapshot] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        return cleaned.filter { $0.deviceID == deviceID }
-    }
-
-    /// 查询首次越狱时间
-    public func getFirstJailbreakTime(for deviceID: String? = nil) -> TimeInterval? {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
-
-        let jailbrokenSnapshots = filtered.filter { $0.jailbreakStatus.isJailbroken }
-        return jailbrokenSnapshots.map { $0.timestamp }.min()
-    }
-
-    /// 查询最近 N 天内的越狱次数
-    public func getJailbreakCount(days: Int = 7, for deviceID: String? = nil) -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let now = Date().timeIntervalSince1970
-        let startTime = now - TimeInterval(days * 24 * 3600)
-
-        let cleaned = cleanAndReturnLocked()
-        let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
-
-        return filtered.filter { $0.timestamp >= startTime && $0.jailbreakStatus.isJailbroken }.count
-    }
-
-    /// 查询首次出现时间（设备年龄）
-    public func getFirstSeenTime(for deviceID: String) -> TimeInterval? {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        let deviceSnapshots = cleaned.filter { $0.deviceID == deviceID }
-        return deviceSnapshots.map { $0.timestamp }.min()
-    }
-
-    /// 获取总检测次数
-    public func getTotalDetectionCount(for deviceID: String) -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let cleaned = cleanAndReturnLocked()
-        return cleaned.filter { $0.deviceID == deviceID }.count
-    }
-
-    /// 获取 VPN 使用频率（最近 N 天）
-    public func getVPNUsageFrequency(days: Int = 7, for deviceID: String? = nil) -> Double {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let now = Date().timeIntervalSince1970
-        let startTime = now - TimeInterval(days * 24 * 3600)
-
-        let cleaned = cleanAndReturnLocked()
-        let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
-        let recentSnapshots = filtered.filter { $0.timestamp >= startTime }
-
-        guard !recentSnapshots.isEmpty else { return 0 }
-
-        let vpnCount = recentSnapshots.filter { $0.isVPNActive }.count
-        return Double(vpnCount) / Double(recentSnapshots.count)
-    }
-
-    /// 获取风险分数历史
-    public func getRiskScoreHistory(days: Int = 30, for deviceID: String? = nil) -> [(timestamp: TimeInterval, score: Double)] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let now = Date().timeIntervalSince1970
-        let startTime = now - TimeInterval(days * 24 * 3600)
-
-        let cleaned = cleanAndReturnLocked()
-        let filtered = deviceID != nil ? cleaned.filter { $0.deviceID == deviceID } : cleaned
-        let recentSnapshots = filtered.filter { $0.timestamp >= startTime }
-
-        return recentSnapshots
-            .sorted { $0.timestamp < $1.timestamp }
-            .map { (timestamp: $0.timestamp, score: $0.riskScore) }
-    }
-
-    // MARK: - 数据清理
-
-    /// 执行数据清理，移除过期快照
-    public func cleanup() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let before = cachedSnapshots.count
-        _ = cleanAndReturnLocked()
-        let after = cachedSnapshots.count
-
-        if before != after {
-            isDirty = true
-            persistIfDirtyLocked()
-        }
-    }
-
-    /// 清空所有历史数据
-    public func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        cachedSnapshots.removeAll()
-        cachedFreshness = .zero
-        isDirty = true
-        persistToDiskLocked(resetAnchor: true)
-    }
-
-    // MARK: - 持久化
-
-    private func loadFromDisk() {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let anchor = freshnessAnchor.read() ?? .zero
-        guard fileManager.fileExists(atPath: storeURL.path) else {
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            isDirty = false
-            return
-        }
-
-        let data: Data
-        do {
-            data = try Data(contentsOf: storeURL)
-        } catch {
-            Logger.log("DeviceHistory: failed to read store file - \(error.localizedDescription)")
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            return
-        }
-
-        guard let signature = (try? Data(contentsOf: hmacURL)),
-              StorageIntegrityGuard.verify(data, signature: signature, purpose: hmacPurpose) else {
-            clearPersistedFilesLocked(resetAnchor: false)
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            return
-        }
-
-        let decryptedData: Data
-        #if DEBUG
-        if let dec = try? PayloadCrypto.decrypt(data) {
-            decryptedData = dec
-        } else {
-            decryptedData = data
-        }
-        #else
-        guard let dec = try? PayloadCrypto.decrypt(data) else {
-            Logger.log("DeviceHistory: decrypt failed, clearing corrupted data in release build")
-            clearPersistedFilesLocked(resetAnchor: false)
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            return
-        }
+    let decryptedData: Data
+    #if DEBUG
+      if let dec = try? PayloadCrypto.decrypt(data) {
         decryptedData = dec
-        #endif
+      } else {
+        decryptedData = data
+      }
+    #else
+      guard let dec = try? PayloadCrypto.decrypt(data) else {
+        Logger.log("DeviceHistory: decrypt failed, clearing corrupted data in release build")
+        clearPersistedFilesLocked(resetAnchor: false)
+        cachedSnapshots = []
+        cachedFreshness = anchor
+        return
+      }
+      decryptedData = dec
+    #endif
 
-        let decodedSnapshots: [DeviceDetectionSnapshot]
-        let diskFreshness: FreshnessState
-        if let envelope = try? JSONDecoder().decode(StoredEnvelope.self, from: decryptedData) {
-            decodedSnapshots = envelope.snapshots
-            diskFreshness = FreshnessState(
-                latestTimestamp: envelope.latestTimestamp,
-                sequence: envelope.sequence
-            )
-        } else if let legacy = try? JSONDecoder().decode([DeviceDetectionSnapshot].self, from: decryptedData) {
-            decodedSnapshots = legacy
-            diskFreshness = FreshnessState(
-                latestTimestamp: legacy.map(\.timestamp).max() ?? 0,
-                sequence: 0
-            )
-        } else {
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            return
-        }
-
-        if diskFreshness.sequence < anchor.sequence && diskFreshness.latestTimestamp < anchor.latestTimestamp {
-            Logger.log("DeviceHistory: freshness rollback detected")
-            clearPersistedFilesLocked(resetAnchor: false)
-            cachedSnapshots = []
-            cachedFreshness = anchor
-            isDirty = false
-            return
-        }
-
-        let cleaned = pruneSnapshotsLocked(decodedSnapshots)
-        cachedSnapshots = cleaned.snapshots
-        cachedFreshness = maxFreshness(anchor, diskFreshness)
-        isDirty = cleaned.didPrune
-
-        if diskFreshness.sequence > anchor.sequence || diskFreshness.latestTimestamp > anchor.latestTimestamp {
-            _ = freshnessAnchor.write(diskFreshness)
-        }
+    let decodedSnapshots: [DeviceDetectionSnapshot]
+    let diskFreshness: FreshnessState
+    if let envelope = try? JSONDecoder().decode(StoredEnvelope.self, from: decryptedData) {
+      decodedSnapshots = envelope.snapshots
+      diskFreshness = FreshnessState(
+        latestTimestamp: envelope.latestTimestamp,
+        sequence: envelope.sequence
+      )
+    } else if let legacy = try? JSONDecoder().decode(
+      [DeviceDetectionSnapshot].self, from: decryptedData)
+    {
+      decodedSnapshots = legacy
+      diskFreshness = FreshnessState(
+        latestTimestamp: legacy.map(\.timestamp).max() ?? 0,
+        sequence: 0
+      )
+    } else {
+      cachedSnapshots = []
+      cachedFreshness = anchor
+      return
     }
 
-    private func persistIfDirty() {
-        lock.lock()
-        defer { lock.unlock() }
-        persistIfDirtyLocked()
+    if diskFreshness.sequence < anchor.sequence
+      && diskFreshness.latestTimestamp < anchor.latestTimestamp
+    {
+      Logger.log("DeviceHistory: freshness rollback detected")
+      clearPersistedFilesLocked(resetAnchor: false)
+      cachedSnapshots = []
+      cachedFreshness = anchor
+      isDirty = false
+      return
     }
 
-    /// Must be called with `lock` already held.
-    private func persistIfDirtyLocked() {
-        guard isDirty else { return }
-        let persisted = persistToDiskLocked(resetAnchor: false)
-        if persisted {
-            isDirty = false
+    let cleaned = pruneSnapshotsLocked(decodedSnapshots)
+    cachedSnapshots = cleaned.snapshots
+    cachedFreshness = maxFreshness(anchor, diskFreshness)
+    isDirty = cleaned.didPrune
+
+    if diskFreshness.sequence > anchor.sequence
+      || diskFreshness.latestTimestamp > anchor.latestTimestamp
+    {
+      _ = freshnessAnchor.write(diskFreshness)
+    }
+  }
+
+  private func persistIfDirty() {
+    lock.lock()
+    defer { lock.unlock() }
+    persistIfDirtyLocked()
+  }
+
+  /// Must be called with `lock` already held.
+  private func persistIfDirtyLocked() {
+    guard isDirty else { return }
+    let persisted = persistToDiskLocked(resetAnchor: false)
+    if persisted {
+      isDirty = false
+    }
+  }
+
+  @discardableResult
+  private func persistToDiskLocked(resetAnchor: Bool) -> Bool {
+    if resetAnchor {
+      clearPersistedFilesLocked(resetAnchor: true)
+      return true
+    }
+
+    do {
+      let anchor = freshnessAnchor.read() ?? .zero
+      let latestSnapshotTimestamp = cachedSnapshots.map(\.timestamp).max() ?? 0
+      let freshness = FreshnessState(
+        latestTimestamp: max(
+          latestSnapshotTimestamp, max(anchor.latestTimestamp, cachedFreshness.latestTimestamp)),
+        sequence: max(anchor.sequence, cachedFreshness.sequence) + 1
+      )
+      let envelope = StoredEnvelope(
+        schemaVersion: 2,
+        snapshots: cachedSnapshots,
+        latestTimestamp: freshness.latestTimestamp,
+        sequence: freshness.sequence
+      )
+      let rawData = try JSONEncoder().encode(envelope)
+      let dataToWrite: Data
+      #if DEBUG
+        dataToWrite = (try? PayloadCrypto.encrypt(rawData)) ?? rawData
+      #else
+        dataToWrite = try PayloadCrypto.encrypt(rawData)
+      #endif
+      try dataToWrite.write(to: storeURL, options: .atomic)
+      try fileManager.setAttributes(
+        [FileAttributeKey.protectionKey: FileProtectionType.complete],
+        ofItemAtPath: storeURL.path
+      )
+      let signature = StorageIntegrityGuard.sign(dataToWrite, purpose: hmacPurpose)
+      try signature.write(to: hmacURL, options: .atomic)
+      try fileManager.setAttributes(
+        [FileAttributeKey.protectionKey: FileProtectionType.complete],
+        ofItemAtPath: hmacURL.path
+      )
+      guard freshnessAnchor.write(freshness) else {
+        Logger.log("DeviceHistory: failed to update freshness anchor")
+        if BuildConfig.isRelease {
+          clearPersistedFilesLocked(resetAnchor: false)
         }
+        return false
+      }
+      cachedFreshness = freshness
+      Logger.log("DeviceHistory: persisted \(cachedSnapshots.count) snapshots (encrypted)")
+      return true
+    } catch {
+      Logger.log("DeviceHistory: failed to persist - \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  // MARK: - 辅助方法
+
+  private func cleanAndReturn() -> [DeviceDetectionSnapshot] {
+    lock.lock()
+    defer { lock.unlock() }
+    return cleanAndReturnLocked()
+  }
+
+  private func cleanAndReturnLocked() -> [DeviceDetectionSnapshot] {
+    let pruned = pruneSnapshotsLocked(cachedSnapshots)
+    cachedSnapshots = pruned.snapshots
+    if pruned.didPrune {
+      isDirty = true
     }
 
-    @discardableResult
-    private func persistToDiskLocked(resetAnchor: Bool) -> Bool {
-        if resetAnchor {
-            clearPersistedFilesLocked(resetAnchor: true)
-            return true
-        }
+    // 按时间戳排序
+    return cachedSnapshots.sorted { $0.timestamp < $1.timestamp }
+  }
 
-        do {
-            let anchor = freshnessAnchor.read() ?? .zero
-            let latestSnapshotTimestamp = cachedSnapshots.map(\.timestamp).max() ?? 0
-            let freshness = FreshnessState(
-                latestTimestamp: max(latestSnapshotTimestamp, max(anchor.latestTimestamp, cachedFreshness.latestTimestamp)),
-                sequence: max(anchor.sequence, cachedFreshness.sequence) + 1
-            )
-            let envelope = StoredEnvelope(
-                schemaVersion: 2,
-                snapshots: cachedSnapshots,
-                latestTimestamp: freshness.latestTimestamp,
-                sequence: freshness.sequence
-            )
-            let rawData = try JSONEncoder().encode(envelope)
-            let dataToWrite: Data
-            #if DEBUG
-            dataToWrite = (try? PayloadCrypto.encrypt(rawData)) ?? rawData
-            #else
-            dataToWrite = try PayloadCrypto.encrypt(rawData)
-            #endif
-            try dataToWrite.write(to: storeURL, options: .atomic)
-            try fileManager.setAttributes(
-                [FileAttributeKey.protectionKey: FileProtectionType.complete],
-                ofItemAtPath: storeURL.path
-            )
-            let signature = StorageIntegrityGuard.sign(dataToWrite, purpose: hmacPurpose)
-            try signature.write(to: hmacURL, options: .atomic)
-            try fileManager.setAttributes(
-                [FileAttributeKey.protectionKey: FileProtectionType.complete],
-                ofItemAtPath: hmacURL.path
-            )
-            guard freshnessAnchor.write(freshness) else {
-                Logger.log("DeviceHistory: failed to update freshness anchor")
-                if BuildConfig.isRelease {
-                    clearPersistedFilesLocked(resetAnchor: false)
-                }
-                return false
-            }
-            cachedFreshness = freshness
-            Logger.log("DeviceHistory: persisted \(cachedSnapshots.count) snapshots (encrypted)")
-            return true
-        } catch {
-            Logger.log("DeviceHistory: failed to persist - \(error.localizedDescription)")
-            return false
-        }
+  private func pruneSnapshotsLocked(_ snapshots: [DeviceDetectionSnapshot]) -> (
+    snapshots: [DeviceDetectionSnapshot], didPrune: Bool
+  ) {
+    let now = Date().timeIntervalSince1970
+    let minTimestamp = now - maxAgeSeconds
+    let timeFiltered = snapshots.filter { $0.timestamp >= minTimestamp }
+    let limited =
+      timeFiltered.count > maxSnapshots ? Array(timeFiltered.suffix(maxSnapshots)) : timeFiltered
+    return (limited, limited.count != snapshots.count)
+  }
+
+  private func clearPersistedFilesLocked(resetAnchor: Bool) {
+    do {
+      try fileManager.removeItem(at: storeURL)
+    } catch {
+      if (error as NSError).code != NSFileNoSuchFileError {
+        Logger.log("DeviceHistory: failed to remove store file - \(error.localizedDescription)")
+      }
     }
-
-    // MARK: - 辅助方法
-
-    private func cleanAndReturn() -> [DeviceDetectionSnapshot] {
-        lock.lock()
-        defer { lock.unlock() }
-        return cleanAndReturnLocked()
+    do {
+      try fileManager.removeItem(at: hmacURL)
+    } catch {
+      if (error as NSError).code != NSFileNoSuchFileError {
+        Logger.log("DeviceHistory: failed to remove hmac file - \(error.localizedDescription)")
+      }
     }
-
-    private func cleanAndReturnLocked() -> [DeviceDetectionSnapshot] {
-        let pruned = pruneSnapshotsLocked(cachedSnapshots)
-        cachedSnapshots = pruned.snapshots
-        if pruned.didPrune {
-            isDirty = true
-        }
-
-        // 按时间戳排序
-        return cachedSnapshots.sorted { $0.timestamp < $1.timestamp }
+    if resetAnchor {
+      freshnessAnchor.remove()
     }
+  }
 
-    private func pruneSnapshotsLocked(_ snapshots: [DeviceDetectionSnapshot]) -> (snapshots: [DeviceDetectionSnapshot], didPrune: Bool) {
-        let now = Date().timeIntervalSince1970
-        let minTimestamp = now - maxAgeSeconds
-        let timeFiltered = snapshots.filter { $0.timestamp >= minTimestamp }
-        let limited = timeFiltered.count > maxSnapshots ? Array(timeFiltered.suffix(maxSnapshots)) : timeFiltered
-        return (limited, limited.count != snapshots.count)
-    }
-
-    private func clearPersistedFilesLocked(resetAnchor: Bool) {
-        do {
-            try fileManager.removeItem(at: storeURL)
-        } catch {
-            if (error as NSError).code != NSFileNoSuchFileError {
-                Logger.log("DeviceHistory: failed to remove store file - \(error.localizedDescription)")
-            }
-        }
-        do {
-            try fileManager.removeItem(at: hmacURL)
-        } catch {
-            if (error as NSError).code != NSFileNoSuchFileError {
-                Logger.log("DeviceHistory: failed to remove hmac file - \(error.localizedDescription)")
-            }
-        }
-        if resetAnchor {
-            freshnessAnchor.remove()
-        }
-    }
-
-    private func maxFreshness(_ lhs: FreshnessState, _ rhs: FreshnessState) -> FreshnessState {
-        FreshnessState(
-            latestTimestamp: max(lhs.latestTimestamp, rhs.latestTimestamp),
-            sequence: max(lhs.sequence, rhs.sequence)
-        )
-    }
+  private func maxFreshness(_ lhs: FreshnessState, _ rhs: FreshnessState) -> FreshnessState {
+    FreshnessState(
+      latestTimestamp: max(lhs.latestTimestamp, rhs.latestTimestamp),
+      sequence: max(lhs.sequence, rhs.sequence)
+    )
+  }
 }

--- a/RiskDetectorApp/Tests/CloudPhoneRiskAppCoreTests/RiskReportStorageTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskAppCoreTests/RiskReportStorageTests.swift
@@ -1,186 +1,227 @@
 import XCTest
+
 @testable import CloudPhoneRiskAppCore
 @testable import CloudPhoneRiskKit
 
 /// RiskReportStorage 单元测试：保存/加载、持久化、错误处理。
 final class RiskReportStorageTests: XCTestCase {
 
-    private var tempDir: URL!
+  private var tempDir: URL!
 
-    override func setUp() {
-        super.setUp()
-        tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  override func setUp() {
+    super.setUp()
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDown() {
+    try? FileManager.default.removeItem(at: tempDir)
+    super.tearDown()
+  }
+
+  // MARK: - reportsDirectoryURL
+
+  func testReportsDirectoryURL_ReturnsValidPath() throws {
+    let url = try RiskReportStorage.reportsDirectoryURL()
+    XCTAssertTrue(url.path.contains("CloudPhoneRiskKit"))
+    XCTAssertEqual(url.lastPathComponent, "reports")
+  }
+
+  func testResolveBaseDirectoryPrefersApplicationSupport() {
+    let appSupport = URL(fileURLWithPath: "/tmp/app-support", isDirectory: true)
+    let caches = URL(fileURLWithPath: "/tmp/caches", isDirectory: true)
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = RiskReportStorage.resolveBaseDirectory(
+      applicationSupportDirectories: [appSupport],
+      cachesDirectories: [caches],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, appSupport)
+  }
+
+  func testResolveBaseDirectoryFallsBackToCaches() {
+    let caches = URL(fileURLWithPath: "/tmp/caches", isDirectory: true)
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = RiskReportStorage.resolveBaseDirectory(
+      applicationSupportDirectories: [],
+      cachesDirectories: [caches],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, caches.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true))
+  }
+
+  func testResolveBaseDirectoryFallsBackToTemporaryDirectory() {
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = RiskReportStorage.resolveBaseDirectory(
+      applicationSupportDirectories: [],
+      cachesDirectories: [],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, temp.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true))
+  }
+
+  // MARK: - list(in:)
+
+  func testList_EmptyDirectoryReturnsEmpty() {
+    let items = RiskReportStorage.list(in: tempDir)
+    XCTAssertTrue(items.isEmpty)
+  }
+
+  func testList_IgnoresMetaFiles() {
+    let metaPath = tempDir.appendingPathComponent("risk-123.json.meta.json")
+    try? "{}".write(to: metaPath, atomically: true, encoding: .utf8)
+    let items = RiskReportStorage.list(in: tempDir)
+    XCTAssertTrue(items.isEmpty, "应忽略 .meta.json 文件")
+  }
+
+  func testList_ReturnsReportsSortedByModifiedDate() {
+    let report1 = tempDir.appendingPathComponent("risk-001.json")
+    let report2 = tempDir.appendingPathComponent("risk-002.json")
+    try? "{\"deviceID\":\"a\"}".write(to: report1, atomically: true, encoding: .utf8)
+    try? "{\"deviceID\":\"b\"}".write(to: report2, atomically: true, encoding: .utf8)
+
+    let items = RiskReportStorage.list(in: tempDir)
+    XCTAssertEqual(items.count, 2)
+    XCTAssertTrue(items[0].filename == "risk-001.json" || items[0].filename == "risk-002.json")
+    XCTAssertEqual(items[0].isEncrypted, false)
+    XCTAssertGreaterThanOrEqual(items[0].bytes, 0)
+  }
+
+  // MARK: - loadJSONString / loadDTO
+
+  func testLoadJSONString_ExistingFile() {
+    let path = tempDir.appendingPathComponent("test-report.json").path
+    let content = "{\"deviceID\":\"test-123\"}"
+    try? content.write(toFile: path, atomically: true, encoding: .utf8)
+
+    #if os(iOS)
+      // iOS 使用 CPRiskStore 解密，测试环境可能不可用
+      _ = RiskReportStorage.loadJSONString(atPath: path)
+    #else
+      let loaded = RiskReportStorage.loadJSONString(atPath: path)
+      XCTAssertEqual(loaded, content)
+    #endif
+  }
+
+  func testLoadJSONString_NonExistentFileReturnsNil() {
+    let path = "/nonexistent/path/risk-999.json"
+    let loaded = RiskReportStorage.loadJSONString(atPath: path)
+    #if os(iOS)
+      _ = loaded
+    #else
+      XCTAssertNil(loaded)
+    #endif
+  }
+
+  func testLoadDTO_ValidJSON() {
+    let json = """
+      {
+        "generatedAt": "2024-01-15T10:00:00.000Z",
+        "deviceID": "storage-test",
+        "score": 30,
+        "isHighRisk": false,
+        "summary": "low_risk",
+        "network": {
+          "interfaceType": {"value": "wifi", "method": "NWPathMonitor"},
+          "isExpensive": false,
+          "isConstrained": false,
+          "vpn": {"detected": false, "method": "ifaddrs", "confidence": "weak"},
+          "proxy": {"detected": false, "method": "CFNetwork", "confidence": "weak"}
+        },
+        "behavior": {
+          "touch": {"sampleCount": 0, "tapCount": 0, "swipeCount": 0},
+          "motion": {"sampleCount": 0},
+          "touchMotionCorrelation": null,
+          "actionCount": 0
+        },
+        "jailbreak": {
+          "isJailbroken": false,
+          "confidence": 0,
+          "detectedMethods": [],
+          "details": ""
+        },
+        "signals": []
+      }
+      """
+    let path = tempDir.appendingPathComponent("valid-report.json").path
+    try? json.write(toFile: path, atomically: true, encoding: .utf8)
+
+    #if os(iOS)
+      _ = RiskReportStorage.loadDTO(atPath: path)
+    #else
+      let dto = RiskReportStorage.loadDTO(atPath: path)
+      XCTAssertNotNil(dto)
+      XCTAssertEqual(dto?.deviceID, "storage-test")
+      XCTAssertEqual(dto?.score, 30)
+    #endif
+  }
+
+  func testLoadDTO_InvalidJSONReturnsNil() {
+    let path = tempDir.appendingPathComponent("invalid.json").path
+    try? "not json".write(toFile: path, atomically: true, encoding: .utf8)
+
+    #if os(iOS)
+      _ = RiskReportStorage.loadDTO(atPath: path)
+    #else
+      let dto = RiskReportStorage.loadDTO(atPath: path)
+      XCTAssertNil(dto)
+    #endif
+  }
+
+  // MARK: - delete / deleteAll
+
+  func testDelete_ExistingFile() {
+    let path = tempDir.appendingPathComponent("to-delete.json").path
+    try? "{}".write(toFile: path, atomically: true, encoding: .utf8)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+
+    let result = RiskReportStorage.delete(atPath: path)
+    XCTAssertTrue(result)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+  }
+
+  func testDelete_NonExistentFileReturnsFalse() {
+    let result = RiskReportStorage.delete(atPath: "/nonexistent/file.json")
+    XCTAssertFalse(result)
+  }
+
+  func testDeleteAll_RemovesAllReports() {
+    let r1 = tempDir.appendingPathComponent("r1.json").path
+    let r2 = tempDir.appendingPathComponent("r2.json").path
+    try? "{}".write(toFile: r1, atomically: true, encoding: .utf8)
+    try? "{}".write(toFile: r2, atomically: true, encoding: .utf8)
+
+    RiskReportStorage.deleteAll()
+    // deleteAll 使用 list() 获取默认目录，不会影响 tempDir；此处仅验证不崩溃
+    _ = RiskReportStorage.list(in: tempDir)
+    try? FileManager.default.removeItem(atPath: r1)
+    try? FileManager.default.removeItem(atPath: r2)
+  }
+
+  // MARK: - StoredRiskReport
+
+  func testStoredRiskReport_IsEncryptedFlag() {
+    let encryptedPath = tempDir.appendingPathComponent("risk.enc")
+    try? Data().write(to: encryptedPath)
+    let items = RiskReportStorage.list(in: tempDir)
+    let enc = items.first { $0.filename.hasSuffix(".enc") }
+    XCTAssertNotNil(enc)
+    XCTAssertTrue(enc?.isEncrypted ?? false)
+
+    let jsonPath = tempDir.appendingPathComponent("risk.json")
+    try? "{}".write(to: jsonPath, atomically: true, encoding: .utf8)
+    let jsonItems = RiskReportStorage.list(in: tempDir)
+    let json = jsonItems.first {
+      $0.filename.hasSuffix(".json") && !$0.filename.hasSuffix(".meta.json")
     }
-
-    override func tearDown() {
-        try? FileManager.default.removeItem(at: tempDir)
-        super.tearDown()
-    }
-
-    // MARK: - reportsDirectoryURL
-
-    func testReportsDirectoryURL_ReturnsValidPath() throws {
-        let url = try RiskReportStorage.reportsDirectoryURL()
-        XCTAssertTrue(url.path.contains("Application Support"))
-        XCTAssertTrue(url.path.contains("CloudPhoneRiskKit"))
-        XCTAssertTrue(url.path.contains("reports"))
-    }
-
-    // MARK: - list(in:)
-
-    func testList_EmptyDirectoryReturnsEmpty() {
-        let items = RiskReportStorage.list(in: tempDir)
-        XCTAssertTrue(items.isEmpty)
-    }
-
-    func testList_IgnoresMetaFiles() {
-        let metaPath = tempDir.appendingPathComponent("risk-123.json.meta.json")
-        try? "{}".write(to: metaPath, atomically: true, encoding: .utf8)
-        let items = RiskReportStorage.list(in: tempDir)
-        XCTAssertTrue(items.isEmpty, "应忽略 .meta.json 文件")
-    }
-
-    func testList_ReturnsReportsSortedByModifiedDate() {
-        let report1 = tempDir.appendingPathComponent("risk-001.json")
-        let report2 = tempDir.appendingPathComponent("risk-002.json")
-        try? "{\"deviceID\":\"a\"}".write(to: report1, atomically: true, encoding: .utf8)
-        try? "{\"deviceID\":\"b\"}".write(to: report2, atomically: true, encoding: .utf8)
-
-        let items = RiskReportStorage.list(in: tempDir)
-        XCTAssertEqual(items.count, 2)
-        XCTAssertTrue(items[0].filename == "risk-001.json" || items[0].filename == "risk-002.json")
-        XCTAssertEqual(items[0].isEncrypted, false)
-        XCTAssertGreaterThanOrEqual(items[0].bytes, 0)
-    }
-
-    // MARK: - loadJSONString / loadDTO
-
-    func testLoadJSONString_ExistingFile() {
-        let path = tempDir.appendingPathComponent("test-report.json").path
-        let content = "{\"deviceID\":\"test-123\"}"
-        try? content.write(toFile: path, atomically: true, encoding: .utf8)
-
-#if os(iOS)
-        // iOS 使用 CPRiskStore 解密，测试环境可能不可用
-        _ = RiskReportStorage.loadJSONString(atPath: path)
-#else
-        let loaded = RiskReportStorage.loadJSONString(atPath: path)
-        XCTAssertEqual(loaded, content)
-#endif
-    }
-
-    func testLoadJSONString_NonExistentFileReturnsNil() {
-        let path = "/nonexistent/path/risk-999.json"
-        let loaded = RiskReportStorage.loadJSONString(atPath: path)
-#if os(iOS)
-        _ = loaded
-#else
-        XCTAssertNil(loaded)
-#endif
-    }
-
-    func testLoadDTO_ValidJSON() {
-        let json = """
-        {
-          "generatedAt": "2024-01-15T10:00:00.000Z",
-          "deviceID": "storage-test",
-          "score": 30,
-          "isHighRisk": false,
-          "summary": "low_risk",
-          "network": {
-            "interfaceType": {"value": "wifi", "method": "NWPathMonitor"},
-            "isExpensive": false,
-            "isConstrained": false,
-            "vpn": {"detected": false, "method": "ifaddrs", "confidence": "weak"},
-            "proxy": {"detected": false, "method": "CFNetwork", "confidence": "weak"}
-          },
-          "behavior": {
-            "touch": {"sampleCount": 0, "tapCount": 0, "swipeCount": 0},
-            "motion": {"sampleCount": 0},
-            "touchMotionCorrelation": null,
-            "actionCount": 0
-          },
-          "jailbreak": {
-            "isJailbroken": false,
-            "confidence": 0,
-            "detectedMethods": [],
-            "details": ""
-          },
-          "signals": []
-        }
-        """
-        let path = tempDir.appendingPathComponent("valid-report.json").path
-        try? json.write(toFile: path, atomically: true, encoding: .utf8)
-
-#if os(iOS)
-        _ = RiskReportStorage.loadDTO(atPath: path)
-#else
-        let dto = RiskReportStorage.loadDTO(atPath: path)
-        XCTAssertNotNil(dto)
-        XCTAssertEqual(dto?.deviceID, "storage-test")
-        XCTAssertEqual(dto?.score, 30)
-#endif
-    }
-
-    func testLoadDTO_InvalidJSONReturnsNil() {
-        let path = tempDir.appendingPathComponent("invalid.json").path
-        try? "not json".write(toFile: path, atomically: true, encoding: .utf8)
-
-#if os(iOS)
-        _ = RiskReportStorage.loadDTO(atPath: path)
-#else
-        let dto = RiskReportStorage.loadDTO(atPath: path)
-        XCTAssertNil(dto)
-#endif
-    }
-
-    // MARK: - delete / deleteAll
-
-    func testDelete_ExistingFile() {
-        let path = tempDir.appendingPathComponent("to-delete.json").path
-        try? "{}".write(toFile: path, atomically: true, encoding: .utf8)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
-
-        let result = RiskReportStorage.delete(atPath: path)
-        XCTAssertTrue(result)
-        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
-    }
-
-    func testDelete_NonExistentFileReturnsFalse() {
-        let result = RiskReportStorage.delete(atPath: "/nonexistent/file.json")
-        XCTAssertFalse(result)
-    }
-
-    func testDeleteAll_RemovesAllReports() {
-        let r1 = tempDir.appendingPathComponent("r1.json").path
-        let r2 = tempDir.appendingPathComponent("r2.json").path
-        try? "{}".write(toFile: r1, atomically: true, encoding: .utf8)
-        try? "{}".write(toFile: r2, atomically: true, encoding: .utf8)
-
-        RiskReportStorage.deleteAll()
-        // deleteAll 使用 list() 获取默认目录，不会影响 tempDir；此处仅验证不崩溃
-        _ = RiskReportStorage.list(in: tempDir)
-        try? FileManager.default.removeItem(atPath: r1)
-        try? FileManager.default.removeItem(atPath: r2)
-    }
-
-    // MARK: - StoredRiskReport
-
-    func testStoredRiskReport_IsEncryptedFlag() {
-        let encryptedPath = tempDir.appendingPathComponent("risk.enc")
-        try? Data().write(to: encryptedPath)
-        let items = RiskReportStorage.list(in: tempDir)
-        let enc = items.first { $0.filename.hasSuffix(".enc") }
-        XCTAssertNotNil(enc)
-        XCTAssertTrue(enc?.isEncrypted ?? false)
-
-        let jsonPath = tempDir.appendingPathComponent("risk.json")
-        try? "{}".write(to: jsonPath, atomically: true, encoding: .utf8)
-        let jsonItems = RiskReportStorage.list(in: tempDir)
-        let json = jsonItems.first { $0.filename.hasSuffix(".json") && !$0.filename.hasSuffix(".meta.json") }
-        XCTAssertNotNil(json)
-        XCTAssertFalse(json?.isEncrypted ?? true)
-    }
+    XCTAssertNotNil(json)
+    XCTAssertFalse(json?.isEncrypted ?? true)
+  }
 }

--- a/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/AnalysisAndUploadPolicyTests.swift
+++ b/RiskDetectorApp/Tests/CloudPhoneRiskKitTests/AnalysisAndUploadPolicyTests.swift
@@ -1,324 +1,369 @@
 import XCTest
+
 @testable import CloudPhoneRiskKit
 
 // MARK: - UploadPolicy Tests
 
 final class UploadPolicyTests: XCTestCase {
 
-    let policy = UploadPolicy()
+  let policy = UploadPolicy()
 
-    // MARK: riskLevel
+  // MARK: riskLevel
 
-    func testHighRiskLevel() {
-        XCTAssertEqual(policy.riskLevel(for: 80), .high)
-        XCTAssertEqual(policy.riskLevel(for: 100), .high)
-        XCTAssertEqual(policy.riskLevel(for: 99), .high)
+  func testHighRiskLevel() {
+    XCTAssertEqual(policy.riskLevel(for: 80), .high)
+    XCTAssertEqual(policy.riskLevel(for: 100), .high)
+    XCTAssertEqual(policy.riskLevel(for: 99), .high)
+  }
+
+  func testMediumRiskLevel() {
+    XCTAssertEqual(policy.riskLevel(for: 50), .medium)
+    XCTAssertEqual(policy.riskLevel(for: 79), .medium)
+    XCTAssertEqual(policy.riskLevel(for: 65), .medium)
+  }
+
+  func testLowRiskLevel() {
+    XCTAssertEqual(policy.riskLevel(for: 0), .low)
+    XCTAssertEqual(policy.riskLevel(for: 49), .low)
+    XCTAssertEqual(policy.riskLevel(for: 30), .low)
+  }
+
+  func testBoundaryThresholds() {
+    XCTAssertEqual(policy.riskLevel(for: 80), .high)
+    XCTAssertEqual(policy.riskLevel(for: 50), .medium)
+    XCTAssertEqual(policy.riskLevel(for: 49), .low)
+  }
+
+  // MARK: shouldImmediateUpload / shouldBatch
+
+  func testShouldImmediateUploadHighRisk() {
+    XCTAssertTrue(policy.shouldImmediateUpload(score: 85))
+    XCTAssertFalse(policy.shouldImmediateUpload(score: 60))
+    XCTAssertFalse(policy.shouldImmediateUpload(score: 20))
+  }
+
+  func testShouldBatchLowRisk() {
+    XCTAssertTrue(policy.shouldBatch(score: 20))
+    XCTAssertFalse(policy.shouldBatch(score: 60))
+    XCTAssertFalse(policy.shouldBatch(score: 90))
+  }
+
+  // MARK: calculateDelay — bounds
+
+  func testCalculateDelayHighRiskNonNegative() {
+    for _ in 0..<50 {
+      let delay = policy.calculateDelay(for: 90)
+      XCTAssertGreaterThanOrEqual(delay, 0, "延迟不得为负")
     }
+  }
 
-    func testMediumRiskLevel() {
-        XCTAssertEqual(policy.riskLevel(for: 50), .medium)
-        XCTAssertEqual(policy.riskLevel(for: 79), .medium)
-        XCTAssertEqual(policy.riskLevel(for: 65), .medium)
+  func testCalculateDelayLowRiskStaysBounded() {
+    // lowRiskBatchInterval=300, jitterRatio=0.2, jitter factor max=±0.5
+    // max jitter = 300 * 0.2 * 0.5 = 30 → delay ∈ [270, 330]
+    let config = UploadPolicy.PolicyConfig(
+      highRiskDelayRange: 0...2,
+      mediumRiskDelayRange: 30...120,
+      lowRiskBatchInterval: 300,
+      jitterRatio: 0.2
+    )
+    let p = UploadPolicy(config: config)
+    for _ in 0..<100 {
+      let delay = p.calculateDelay(for: 10)
+      XCTAssertGreaterThanOrEqual(delay, 0)
+      // Max possible: 300 + 300*0.2*0.5 = 330
+      XCTAssertLessThanOrEqual(delay, 330.001, "抖动不应超过 ±0.5×jitterRatio×base")
     }
+  }
 
-    func testLowRiskLevel() {
-        XCTAssertEqual(policy.riskLevel(for: 0), .low)
-        XCTAssertEqual(policy.riskLevel(for: 49), .low)
-        XCTAssertEqual(policy.riskLevel(for: 30), .low)
-    }
+  // MARK: strict / lenient presets
 
-    func testBoundaryThresholds() {
-        XCTAssertEqual(policy.riskLevel(for: 80), .high)
-        XCTAssertEqual(policy.riskLevel(for: 50), .medium)
-        XCTAssertEqual(policy.riskLevel(for: 49), .low)
-    }
+  func testStrictPresetHigherSensitivity() {
+    XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 70), .high)
+    XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 69), .medium)
+  }
 
-    // MARK: shouldImmediateUpload / shouldBatch
+  func testLenientPresetLowerSensitivity() {
+    XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 89), .medium)
+    XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 90), .high)
+  }
 
-    func testShouldImmediateUploadHighRisk() {
-        XCTAssertTrue(policy.shouldImmediateUpload(score: 85))
-        XCTAssertFalse(policy.shouldImmediateUpload(score: 60))
-        XCTAssertFalse(policy.shouldImmediateUpload(score: 20))
-    }
+  // MARK: nextBatchDelay
 
-    func testShouldBatchLowRisk() {
-        XCTAssertTrue(policy.shouldBatch(score: 20))
-        XCTAssertFalse(policy.shouldBatch(score: 60))
-        XCTAssertFalse(policy.shouldBatch(score: 90))
-    }
+  func testNextBatchDelayInFuture() {
+    let now = Date().timeIntervalSince1970
+    let delay = policy.nextBatchDelay(since: now)
+    // batch interval = 300s, just started → remaining ≈ 300
+    XCTAssertGreaterThan(delay, 290)
+    XCTAssertLessThanOrEqual(delay, 300.1)
+  }
 
-    // MARK: calculateDelay — bounds
-
-    func testCalculateDelayHighRiskNonNegative() {
-        for _ in 0..<50 {
-            let delay = policy.calculateDelay(for: 90)
-            XCTAssertGreaterThanOrEqual(delay, 0, "延迟不得为负")
-        }
-    }
-
-    func testCalculateDelayLowRiskStaysBounded() {
-        // lowRiskBatchInterval=300, jitterRatio=0.2, jitter factor max=±0.5
-        // max jitter = 300 * 0.2 * 0.5 = 30 → delay ∈ [270, 330]
-        let config = UploadPolicy.PolicyConfig(
-            highRiskDelayRange: 0...2,
-            mediumRiskDelayRange: 30...120,
-            lowRiskBatchInterval: 300,
-            jitterRatio: 0.2
-        )
-        let p = UploadPolicy(config: config)
-        for _ in 0..<100 {
-            let delay = p.calculateDelay(for: 10)
-            XCTAssertGreaterThanOrEqual(delay, 0)
-            // Max possible: 300 + 300*0.2*0.5 = 330
-            XCTAssertLessThanOrEqual(delay, 330.001, "抖动不应超过 ±0.5×jitterRatio×base")
-        }
-    }
-
-    // MARK: strict / lenient presets
-
-    func testStrictPresetHigherSensitivity() {
-        XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 70), .high)
-        XCTAssertEqual(UploadPolicy.strict.riskLevel(for: 69), .medium)
-    }
-
-    func testLenientPresetLowerSensitivity() {
-        XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 89), .medium)
-        XCTAssertEqual(UploadPolicy.lenient.riskLevel(for: 90), .high)
-    }
-
-    // MARK: nextBatchDelay
-
-    func testNextBatchDelayInFuture() {
-        let now = Date().timeIntervalSince1970
-        let delay = policy.nextBatchDelay(since: now)
-        // batch interval = 300s, just started → remaining ≈ 300
-        XCTAssertGreaterThan(delay, 290)
-        XCTAssertLessThanOrEqual(delay, 300.1)
-    }
-
-    func testNextBatchDelayElapsed() {
-        let past = Date().timeIntervalSince1970 - 400
-        let delay = policy.nextBatchDelay(since: past)
-        XCTAssertEqual(delay, 0, "已过期应返回 0")
-    }
+  func testNextBatchDelayElapsed() {
+    let past = Date().timeIntervalSince1970 - 400
+    let delay = policy.nextBatchDelay(since: past)
+    XCTAssertEqual(delay, 0, "已过期应返回 0")
+  }
 }
 
 // MARK: - AnomalyDetector Tests
 
 final class AnomalyDetectorTests: XCTestCase {
 
-    let detector = AnomalyDetector()
+  let detector = AnomalyDetector()
 
-    // MARK: Z-score
+  // MARK: Z-score
 
-    func testZScoreInsufficientSamples() {
-        let result = detector.detectZScore(value: 100, samples: [1, 2])
-        XCTAssertFalse(result.isAnomalous)
-        XCTAssertEqual(result.zScore, 0)
-    }
+  func testZScoreInsufficientSamples() {
+    let result = detector.detectZScore(value: 100, samples: [1, 2])
+    XCTAssertFalse(result.isAnomalous)
+    XCTAssertEqual(result.zScore, 0)
+  }
 
-    func testZScoreNotAnomalous() {
-        let samples = [10.0, 10.0, 10.0, 10.0, 10.0]
-        // All values equal → stdDev = 0 → not anomalous
-        let result = detector.detectZScore(value: 10, samples: samples)
-        XCTAssertFalse(result.isAnomalous)
-    }
+  func testZScoreNotAnomalous() {
+    let samples = [10.0, 10.0, 10.0, 10.0, 10.0]
+    // All values equal → stdDev = 0 → not anomalous
+    let result = detector.detectZScore(value: 10, samples: samples)
+    XCTAssertFalse(result.isAnomalous)
+  }
 
-    func testZScoreAnomalousOutlier() {
-        let samples = Array(repeating: 10.0, count: 20) + [10.0, 10.0, 10.0]
-        let result = detector.detectZScore(value: 100.0, samples: samples, threshold: 2.0)
-        XCTAssertTrue(result.isAnomalous)
-        XCTAssertGreaterThan(result.zScore, 2.0)
-    }
+  func testZScoreAnomalousOutlier() {
+    let samples = Array(repeating: 10.0, count: 20) + [10.0, 10.0, 10.0]
+    let result = detector.detectZScore(value: 100.0, samples: samples, threshold: 2.0)
+    XCTAssertTrue(result.isAnomalous)
+    XCTAssertGreaterThan(result.zScore, 2.0)
+  }
 
-    func testZScoreNormalValue() {
-        let samples = [10.0, 12.0, 11.0, 13.0, 10.0, 11.0, 12.0, 13.0, 11.0, 10.0]
-        let result = detector.detectZScore(value: 11.5, samples: samples, threshold: 3.0)
-        XCTAssertFalse(result.isAnomalous)
-    }
+  func testZScoreNormalValue() {
+    let samples = [10.0, 12.0, 11.0, 13.0, 10.0, 11.0, 12.0, 13.0, 11.0, 10.0]
+    let result = detector.detectZScore(value: 11.5, samples: samples, threshold: 3.0)
+    XCTAssertFalse(result.isAnomalous)
+  }
 
-    // MARK: IQR
+  // MARK: IQR
 
-    func testIQRInsufficientSamples() {
-        let result = detector.detectIQR(value: 50, samples: [1, 2, 3])
-        XCTAssertFalse(result.isAnomalous)
-    }
+  func testIQRInsufficientSamples() {
+    let result = detector.detectIQR(value: 50, samples: [1, 2, 3])
+    XCTAssertFalse(result.isAnomalous)
+  }
 
-    func testIQRNormalValue() {
-        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
-        let result = detector.detectIQR(value: 45.0, samples: samples)
-        XCTAssertFalse(result.isAnomalous)
-    }
+  func testIQRNormalValue() {
+    let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+    let result = detector.detectIQR(value: 45.0, samples: samples)
+    XCTAssertFalse(result.isAnomalous)
+  }
 
-    func testIQRHighOutlier() {
-        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
-        let result = detector.detectIQR(value: 200.0, samples: samples)
-        XCTAssertTrue(result.isAnomalous)
-        XCTAssertTrue(result.isAboveUpperBound)
-        XCTAssertFalse(result.isBelowLowerBound)
-    }
+  func testIQRHighOutlier() {
+    let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+    let result = detector.detectIQR(value: 200.0, samples: samples)
+    XCTAssertTrue(result.isAnomalous)
+    XCTAssertTrue(result.isAboveUpperBound)
+    XCTAssertFalse(result.isBelowLowerBound)
+  }
 
-    func testIQRLowOutlier() {
-        let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
-        let result = detector.detectIQR(value: -100.0, samples: samples)
-        XCTAssertTrue(result.isAnomalous)
-        XCTAssertTrue(result.isBelowLowerBound)
-    }
+  func testIQRLowOutlier() {
+    let samples = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+    let result = detector.detectIQR(value: -100.0, samples: samples)
+    XCTAssertTrue(result.isAnomalous)
+    XCTAssertTrue(result.isBelowLowerBound)
+  }
 
-    /// Q1/Q3 should be computed via linear interpolation, not raw integer index.
-    /// For sorted=[10,20,30,40,50]: correct Q1=17.5, Q3=42.5
-    func testIQRInterpolationCorrectness() {
-        let samples = [30.0, 10.0, 50.0, 20.0, 40.0] // sorted: [10,20,30,40,50]
-        let result = detector.detectIQR(value: 30.0, samples: samples)
-        // Q1 = interpolated 25th percentile of [10,20,30,40,50] = 17.5
-        // Q3 = interpolated 75th percentile = 42.5
-        // IQR = 25, lower = 17.5 - 1.5*25 = -20, upper = 42.5 + 1.5*25 = 80
-        XCTAssertFalse(result.isAnomalous, "30 should be within IQR bounds")
-        XCTAssertEqual(result.lowerBound, -20.0, accuracy: 0.01)
-        XCTAssertEqual(result.upperBound, 80.0, accuracy: 0.01)
-    }
+  /// Q1/Q3 should be computed via linear interpolation, not raw integer index.
+  /// For sorted=[10,20,30,40,50]: correct Q1=17.5, Q3=42.5
+  func testIQRInterpolationCorrectness() {
+    let samples = [30.0, 10.0, 50.0, 20.0, 40.0]  // sorted: [10,20,30,40,50]
+    let result = detector.detectIQR(value: 30.0, samples: samples)
+    // Q1 = interpolated 25th percentile of [10,20,30,40,50] = 17.5
+    // Q3 = interpolated 75th percentile = 42.5
+    // IQR = 25, lower = 17.5 - 1.5*25 = -20, upper = 42.5 + 1.5*25 = 80
+    XCTAssertFalse(result.isAnomalous, "30 should be within IQR bounds")
+    XCTAssertEqual(result.lowerBound, -20.0, accuracy: 0.01)
+    XCTAssertEqual(result.upperBound, 80.0, accuracy: 0.01)
+  }
 
-    func testIQRAllSameValues() {
-        // IQR = 0 → no anomaly detection possible
-        let samples = [5.0, 5.0, 5.0, 5.0, 5.0]
-        let result = detector.detectIQR(value: 5.0, samples: samples)
-        XCTAssertFalse(result.isAnomalous)
-    }
+  func testIQRAllSameValues() {
+    // IQR = 0 → no anomaly detection possible
+    let samples = [5.0, 5.0, 5.0, 5.0, 5.0]
+    let result = detector.detectIQR(value: 5.0, samples: samples)
+    XCTAssertFalse(result.isAnomalous)
+  }
 }
 
 // MARK: - StatisticalFeatures / BehaviorBaseline Tests
 
 final class StatisticalFeaturesTests: XCTestCase {
 
-    // MARK: percentile interpolation via StatisticalFeatures.from
+  // MARK: percentile interpolation via StatisticalFeatures.from
 
-    func testPercentile25SingleElement() {
-        let features = StatisticalFeatures.from([42.0])
-        XCTAssertNotNil(features)
-        XCTAssertEqual(features!.percentile25, 42.0, accuracy: 0.001)
-        XCTAssertEqual(features!.percentile75, 42.0, accuracy: 0.001)
-    }
+  func testPercentile25SingleElement() {
+    let features = StatisticalFeatures.from([42.0])
+    XCTAssertNotNil(features)
+    XCTAssertEqual(features!.percentile25, 42.0, accuracy: 0.001)
+    XCTAssertEqual(features!.percentile75, 42.0, accuracy: 0.001)
+  }
 
-    func testPercentileInterpolationFiveElements() {
-        // sorted: [10, 20, 30, 40, 50]
-        let features = StatisticalFeatures.from([30.0, 10.0, 50.0, 20.0, 40.0])
-        XCTAssertNotNil(features)
-        // p25 = 0.25 * 4 = index 1.0 = 20.0
-        XCTAssertEqual(features!.percentile25, 17.5, accuracy: 0.01)
-        // p75 = 0.75 * 4 = index 3.0 = 40.0
-        XCTAssertEqual(features!.percentile75, 42.5, accuracy: 0.01)
-    }
+  func testPercentileInterpolationFiveElements() {
+    // sorted: [10, 20, 30, 40, 50]
+    let features = StatisticalFeatures.from([30.0, 10.0, 50.0, 20.0, 40.0])
+    XCTAssertNotNil(features)
+    // p25 = 0.25 * 4 = index 1.0 = 20.0
+    XCTAssertEqual(features!.percentile25, 17.5, accuracy: 0.01)
+    // p75 = 0.75 * 4 = index 3.0 = 40.0
+    XCTAssertEqual(features!.percentile75, 42.5, accuracy: 0.01)
+  }
 
-    func testPercentileEmptyReturnsNil() {
-        XCTAssertNil(StatisticalFeatures.from([]))
-    }
+  func testPercentileEmptyReturnsNil() {
+    XCTAssertNil(StatisticalFeatures.from([]))
+  }
 
-    func testMedianEvenCount() {
-        // sorted: [1, 2, 3, 4] → median = (2+3)/2 = 2.5
-        let features = StatisticalFeatures.from([3.0, 1.0, 4.0, 2.0])
-        XCTAssertNotNil(features)
-        XCTAssertEqual(features!.median, 2.5, accuracy: 0.001)
-    }
+  func testMedianEvenCount() {
+    // sorted: [1, 2, 3, 4] → median = (2+3)/2 = 2.5
+    let features = StatisticalFeatures.from([3.0, 1.0, 4.0, 2.0])
+    XCTAssertNotNil(features)
+    XCTAssertEqual(features!.median, 2.5, accuracy: 0.001)
+  }
 
-    func testMedianOddCount() {
-        // sorted: [1, 2, 3] → median = 2
-        let features = StatisticalFeatures.from([3.0, 1.0, 2.0])
-        XCTAssertNotNil(features)
-        XCTAssertEqual(features!.median, 2.0, accuracy: 0.001)
-    }
+  func testMedianOddCount() {
+    // sorted: [1, 2, 3] → median = 2
+    let features = StatisticalFeatures.from([3.0, 1.0, 2.0])
+    XCTAssertNotNil(features)
+    XCTAssertEqual(features!.median, 2.0, accuracy: 0.001)
+  }
 
-    func testMeanAndStdDev() {
-        let features = StatisticalFeatures.from([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
-        XCTAssertNotNil(features)
-        XCTAssertEqual(features!.mean, 5.0, accuracy: 0.001)
-        XCTAssertEqual(features!.stdDev, 2.0, accuracy: 0.001)
-    }
+  func testMeanAndStdDev() {
+    let features = StatisticalFeatures.from([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
+    XCTAssertNotNil(features)
+    XCTAssertEqual(features!.mean, 5.0, accuracy: 0.001)
+    XCTAssertEqual(features!.stdDev, 2.0, accuracy: 0.001)
+  }
 
-    func testCoefficientOfVariationZeroMean() {
-        // mean=0 → cv should be 0, not NaN
-        let features = StatisticalFeatures.from([0.0, 0.0, 0.0])
-        XCTAssertNotNil(features)
-        XCTAssertFalse(features!.coefficientOfVariation.isNaN)
-        XCTAssertEqual(features!.coefficientOfVariation, 0.0)
-    }
+  func testCoefficientOfVariationZeroMean() {
+    // mean=0 → cv should be 0, not NaN
+    let features = StatisticalFeatures.from([0.0, 0.0, 0.0])
+    XCTAssertNotNil(features)
+    XCTAssertFalse(features!.coefficientOfVariation.isNaN)
+    XCTAssertEqual(features!.coefficientOfVariation, 0.0)
+  }
 
-    func testIQRCalculation() {
-        let features = StatisticalFeatures.from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-        XCTAssertNotNil(features)
-        // IQR = p75 - p25, should be positive
-        XCTAssertGreaterThan(features!.iqr, 0)
-        XCTAssertEqual(features!.iqr, features!.percentile75 - features!.percentile25, accuracy: 0.001)
-    }
+  func testIQRCalculation() {
+    let features = StatisticalFeatures.from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    XCTAssertNotNil(features)
+    // IQR = p75 - p25, should be positive
+    XCTAssertGreaterThan(features!.iqr, 0)
+    XCTAssertEqual(features!.iqr, features!.percentile75 - features!.percentile25, accuracy: 0.001)
+  }
 }
 
 // MARK: - TemporalFeatures Regression Slope Tests
 
 final class TemporalFeaturesRegressionTests: XCTestCase {
 
-    private func makeSnapshot(deviceID: String = "dev1", score: Double, offset: TimeInterval) -> DeviceDetectionSnapshot {
-        DeviceDetectionSnapshot(
-            timestamp: Date().timeIntervalSince1970 - offset,
-            deviceID: deviceID,
-            riskScore: score,
-            isHighRisk: score >= 60,
-            jailbreakStatus: JailbreakStatus(isJailbroken: false, confidence: 0.1, detectedMethods: []),
-            isVPNActive: false,
-            isProxyEnabled: false,
-            networkInterfaceType: "wifi"
-        )
-    }
+  private func makeSnapshot(deviceID: String = "dev1", score: Double, offset: TimeInterval)
+    -> DeviceDetectionSnapshot
+  {
+    DeviceDetectionSnapshot(
+      timestamp: Date().timeIntervalSince1970 - offset,
+      deviceID: deviceID,
+      riskScore: score,
+      isHighRisk: score >= 60,
+      jailbreakStatus: JailbreakStatus(isJailbroken: false, confidence: 0.1, detectedMethods: []),
+      isVPNActive: false,
+      isProxyEnabled: false,
+      networkInterfaceType: "wifi"
+    )
+  }
 
-    /// All scores identical → denominator = 0 → should return .stable
-    func testRegressionDenominatorZeroReturnStable() {
-        // Build a calculator with snapshots that all have the same score
-        let history = DeviceHistory.shared
-        let deviceID = "test_regression_stable_\(UUID().uuidString)"
-        for i in 0..<5 {
-            let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: TimeInterval(i * 3600))
-            history.addSnapshot(snap)
-        }
-        let calculator = TemporalFeaturesCalculator(history: history)
-        let features = calculator.calculate(for: deviceID)
-        // Flat line → stable
-        XCTAssertEqual(features.riskTrend, .stable)
+  /// All scores identical → denominator = 0 → should return .stable
+  func testRegressionDenominatorZeroReturnStable() {
+    // Build a calculator with snapshots that all have the same score
+    let history = DeviceHistory.shared
+    let deviceID = "test_regression_stable_\(UUID().uuidString)"
+    for i in 0..<5 {
+      let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: TimeInterval(i * 3600))
+      history.addSnapshot(snap)
     }
+    let calculator = TemporalFeaturesCalculator(history: history)
+    let features = calculator.calculate(for: deviceID)
+    // Flat line → stable
+    XCTAssertEqual(features.riskTrend, .stable)
+  }
 
-    /// Monotonically increasing scores → deteriorating
-    func testRegressionIncreasingScoresDeteriorate() {
-        let history = DeviceHistory.shared
-        let deviceID = "test_regression_increase_\(UUID().uuidString)"
-        let scores = [10.0, 25.0, 40.0, 55.0, 70.0, 85.0]
-        for (i, score) in scores.enumerated() {
-            let snap = makeSnapshot(deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
-            history.addSnapshot(snap)
-        }
-        let calculator = TemporalFeaturesCalculator(history: history)
-        let features = calculator.calculate(for: deviceID)
-        XCTAssertEqual(features.riskTrend, .deteriorating)
+  /// Monotonically increasing scores → deteriorating
+  func testRegressionIncreasingScoresDeteriorate() {
+    let history = DeviceHistory.shared
+    let deviceID = "test_regression_increase_\(UUID().uuidString)"
+    let scores = [10.0, 25.0, 40.0, 55.0, 70.0, 85.0]
+    for (i, score) in scores.enumerated() {
+      let snap = makeSnapshot(
+        deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
+      history.addSnapshot(snap)
     }
+    let calculator = TemporalFeaturesCalculator(history: history)
+    let features = calculator.calculate(for: deviceID)
+    XCTAssertEqual(features.riskTrend, .deteriorating)
+  }
 
-    /// Monotonically decreasing scores → improving
-    func testRegressionDecreasingScoresImprove() {
-        let history = DeviceHistory.shared
-        let deviceID = "test_regression_decrease_\(UUID().uuidString)"
-        let scores = [85.0, 70.0, 55.0, 40.0, 25.0, 10.0]
-        for (i, score) in scores.enumerated() {
-            let snap = makeSnapshot(deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
-            history.addSnapshot(snap)
-        }
-        let calculator = TemporalFeaturesCalculator(history: history)
-        let features = calculator.calculate(for: deviceID)
-        XCTAssertEqual(features.riskTrend, .improving)
+  /// Monotonically decreasing scores → improving
+  func testRegressionDecreasingScoresImprove() {
+    let history = DeviceHistory.shared
+    let deviceID = "test_regression_decrease_\(UUID().uuidString)"
+    let scores = [85.0, 70.0, 55.0, 40.0, 25.0, 10.0]
+    for (i, score) in scores.enumerated() {
+      let snap = makeSnapshot(
+        deviceID: deviceID, score: score, offset: TimeInterval((scores.count - i) * 3600))
+      history.addSnapshot(snap)
     }
+    let calculator = TemporalFeaturesCalculator(history: history)
+    let features = calculator.calculate(for: deviceID)
+    XCTAssertEqual(features.riskTrend, .improving)
+  }
 
-    /// Fewer than 3 snapshots → unknown
-    func testRegressionInsufficientDataReturnsUnknown() {
-        let history = DeviceHistory.shared
-        let deviceID = "test_regression_unknown_\(UUID().uuidString)"
-        let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: 0)
-        history.addSnapshot(snap)
-        let calculator = TemporalFeaturesCalculator(history: history)
-        let features = calculator.calculate(for: deviceID)
-        XCTAssertEqual(features.riskTrend, .unknown)
-    }
+  /// Fewer than 3 snapshots → unknown
+  func testRegressionInsufficientDataReturnsUnknown() {
+    let history = DeviceHistory.shared
+    let deviceID = "test_regression_unknown_\(UUID().uuidString)"
+    let snap = makeSnapshot(deviceID: deviceID, score: 50.0, offset: 0)
+    history.addSnapshot(snap)
+    let calculator = TemporalFeaturesCalculator(history: history)
+    let features = calculator.calculate(for: deviceID)
+    XCTAssertEqual(features.riskTrend, .unknown)
+  }
+
+  func testDeviceHistoryResolveStorageDirectoryPrefersApplicationSupport() {
+    let appSupport = URL(fileURLWithPath: "/tmp/app-support", isDirectory: true)
+    let caches = URL(fileURLWithPath: "/tmp/caches", isDirectory: true)
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = DeviceHistory.resolveStorageDirectory(
+      applicationSupportDirectories: [appSupport],
+      cachesDirectories: [caches],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, appSupport)
+  }
+
+  func testDeviceHistoryResolveStorageDirectoryFallsBackToCaches() {
+    let caches = URL(fileURLWithPath: "/tmp/caches", isDirectory: true)
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = DeviceHistory.resolveStorageDirectory(
+      applicationSupportDirectories: [],
+      cachesDirectories: [caches],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, caches.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true))
+  }
+
+  func testDeviceHistoryResolveStorageDirectoryFallsBackToTemporaryDirectory() {
+    let temp = URL(fileURLWithPath: "/tmp/temp", isDirectory: true)
+
+    let resolved = DeviceHistory.resolveStorageDirectory(
+      applicationSupportDirectories: [],
+      cachesDirectories: [],
+      temporaryDirectory: temp
+    )
+
+    XCTAssertEqual(resolved, temp.appendingPathComponent("CloudPhoneRiskKit", isDirectory: true))
+  }
+
 }


### PR DESCRIPTION
### Motivation
- Make storage resilient in environments where `Application Support` is unavailable by adding explicit resolution and fallbacks to `Caches` and `Temporary` directories.
- Improve testability by extracting directory resolution logic so tests can provide controlled directory arrays instead of relying on system defaults.
- Centralize and clarify directory selection and logging behavior for both report storage and device history.

### Description
- Added `RiskReportStorage.resolveBaseDirectory(...)` to compute a base storage URL preferring Application Support, then Caches, then Temporary, and used it in `reportsDirectoryURL()`.
- Added `DeviceHistory.resolveStorageDirectory(...)` (and a convenience overload taking a `FileManager`) and updated `DeviceHistory` to create/read storage under the resolved directory and to log when falling back to caches/temporary directories.
- Kept existing persistence, encryption, freshness and integrity logic while reorganizing initialization and small readability/formatting changes across `RiskReportStorage.swift` and `DeviceHistory.swift`.
- Updated and extended unit tests to validate resolver behavior and adapted existing tests to match the new storage-resolution semantics.

### Testing
- Ran unit tests with `swift test` covering `RiskReportStorageTests`, `AnalysisAndUploadPolicyTests`, `AnomalyDetectorTests`, `StatisticalFeaturesTests`, and `TemporalFeaturesRegressionTests` including new resolver tests, and all tests passed.
- Added tests: `testResolveBaseDirectory*` in `RiskReportStorageTests` and `testDeviceHistoryResolveStorageDirectory*` in regression tests; these validate fallback behavior and expected paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba55525858832da414e2bd328034f0)