### PR TITLE
fix(armor): prevent SP corruption in Pass 8 instruction substitution

### DIFF
--- a/cprisk-armor/Sources/InstructionSubstitution/ARM64Codec.swift
+++ b/cprisk-armor/Sources/InstructionSubstitution/ARM64Codec.swift
@@ -485,15 +485,15 @@ public enum ARM64Codec {
 
         guard setFlags == 0, imm12 == 0 else { return nil }
 
-        let width = registerWidth(from: rawValue)
-        if rd == ARM64RegisterWidth.zeroRegisterIndex {
-            let form: ARM64NoEffectForm = isSub ? .discardViaSubZero : .discardViaAddZero
-            return ARM64DecodedInstruction(
-                rawValue: rawValue,
-                kind: .noEffect(ARM64NoEffect(form: form, sourceRegister: rn, width: width))
-            )
+        // In ADD/SUB immediate, register 31 encodes SP (not XZR).
+        // We must exclude any instruction that reads or writes SP, because
+        // logical-register replacements treat register 31 as XZR.
+        guard rn != ARM64RegisterWidth.zeroRegisterIndex,
+              rd != ARM64RegisterWidth.zeroRegisterIndex else {
+            return nil
         }
 
+        let width = registerWidth(from: rawValue)
         let form: ARM64RegisterCopyForm = isSub ? .subZero : .addZero
         return ARM64DecodedInstruction(
             rawValue: rawValue,
@@ -509,7 +509,9 @@ public enum ARM64Codec {
     private static func decodeMoveWideImmediate(_ rawValue: UInt32) -> ARM64DecodedInstruction? {
         let moveWideMask: UInt32 = 0x7F80_0000
         let opcode = rawValue & moveWideMask
-        guard opcode == 0x5280_0000 || opcode == 0xD280_0000 else { return nil }
+        // The mask clears bit 31 (sf), so both W-form (0x5280_0000) and
+        // X-form produce the same masked value.  A single check suffices.
+        guard opcode == 0x5280_0000 else { return nil }
 
         let width = registerWidth(from: rawValue)
         let halfwordShift = (rawValue >> 21) & 0x3

--- a/cprisk-armor/Sources/InstructionSubstitution/SubstitutionEngine.swift
+++ b/cprisk-armor/Sources/InstructionSubstitution/SubstitutionEngine.swift
@@ -226,7 +226,13 @@ public final class SubstitutionEngine {
 
         switch decoded.kind {
         case .registerCopy(let copy):
-            options = orderedUniqueOptions(excluding: decoded.rawValue, options: [
+            // In ADD/SUB immediate, register 31 encodes SP (not XZR).
+            // Only offer ADD/SUB alternatives when neither operand is register 31,
+            // to avoid accidentally reading SP or writing SP.
+            let canUseAddSub = copy.sourceRegister != ARM64RegisterWidth.zeroRegisterIndex
+                && copy.destinationRegister != ARM64RegisterWidth.zeroRegisterIndex
+
+            var copyOptions = [
                 ReplacementOption(
                     rawValue: ARM64Codec.encodeMoveAlias(
                         destinationRegister: copy.destinationRegister,
@@ -234,22 +240,6 @@ public final class SubstitutionEngine {
                         width: copy.width
                     ),
                     description: ARM64RegisterCopyForm.movAlias.description
-                ),
-                ReplacementOption(
-                    rawValue: ARM64Codec.encodeAddImmediateZero(
-                        destinationRegister: copy.destinationRegister,
-                        sourceRegister: copy.sourceRegister,
-                        width: copy.width
-                    ),
-                    description: ARM64RegisterCopyForm.addZero.description
-                ),
-                ReplacementOption(
-                    rawValue: ARM64Codec.encodeSubImmediateZero(
-                        destinationRegister: copy.destinationRegister,
-                        sourceRegister: copy.sourceRegister,
-                        width: copy.width
-                    ),
-                    description: ARM64RegisterCopyForm.subZero.description
                 ),
                 ReplacementOption(
                     rawValue: ARM64Codec.encodeAndSelf(
@@ -267,13 +257,36 @@ public final class SubstitutionEngine {
                     ),
                     description: ARM64RegisterCopyForm.orrSelf.description
                 ),
-            ])
+            ]
+
+            if canUseAddSub {
+                copyOptions.append(contentsOf: [
+                    ReplacementOption(
+                        rawValue: ARM64Codec.encodeAddImmediateZero(
+                            destinationRegister: copy.destinationRegister,
+                            sourceRegister: copy.sourceRegister,
+                            width: copy.width
+                        ),
+                        description: ARM64RegisterCopyForm.addZero.description
+                    ),
+                    ReplacementOption(
+                        rawValue: ARM64Codec.encodeSubImmediateZero(
+                            destinationRegister: copy.destinationRegister,
+                            sourceRegister: copy.sourceRegister,
+                            width: copy.width
+                        ),
+                        description: ARM64RegisterCopyForm.subZero.description
+                    ),
+                ])
+            }
+
+            options = orderedUniqueOptions(excluding: decoded.rawValue, options: copyOptions)
 
         case .noEffect(let noEffect):
             let width = noEffect.width
             let source = noEffect.sourceRegister ?? ARM64RegisterWidth.zeroRegisterIndex
             var candidates = [ReplacementOption]()
-            candidates.reserveCapacity(6)
+            candidates.reserveCapacity(4)
 
             if source == ARM64RegisterWidth.zeroRegisterIndex {
                 candidates.append(ReplacementOption(
@@ -282,6 +295,10 @@ public final class SubstitutionEngine {
                 ))
             }
 
+            // No-effect destination is always register 31 (XZR in logical
+            // context). ADD/SUB immediate treats register 31 as SP, so
+            // generating ADD/SUB XZR replacements would corrupt the stack
+            // pointer.  Only use logical-register forms here.
             candidates.append(contentsOf: [
                 ReplacementOption(
                     rawValue: ARM64Codec.encodeMoveAlias(
@@ -290,22 +307,6 @@ public final class SubstitutionEngine {
                         width: width
                     ),
                     description: ARM64NoEffectForm.discardViaMove.description
-                ),
-                ReplacementOption(
-                    rawValue: ARM64Codec.encodeAddImmediateZero(
-                        destinationRegister: ARM64RegisterWidth.zeroRegisterIndex,
-                        sourceRegister: source,
-                        width: width
-                    ),
-                    description: ARM64NoEffectForm.discardViaAddZero.description
-                ),
-                ReplacementOption(
-                    rawValue: ARM64Codec.encodeSubImmediateZero(
-                        destinationRegister: ARM64RegisterWidth.zeroRegisterIndex,
-                        sourceRegister: source,
-                        width: width
-                    ),
-                    description: ARM64NoEffectForm.discardViaSubZero.description
                 ),
                 ReplacementOption(
                     rawValue: ARM64Codec.encodeAndSelf(

--- a/cprisk-armor/Tests/MachOKitTests/InstructionSubstitutionTests.swift
+++ b/cprisk-armor/Tests/MachOKitTests/InstructionSubstitutionTests.swift
@@ -58,9 +58,10 @@ final class InstructionSubstitutionTests: XCTestCase {
                 "NOP",
                 Self.nop,
                 [
+                    // ADD/SUB with dest=31 would write SP, not XZR — excluded.
+                    // MOV-alias and ORR-self both encode identically for XZR,
+                    // so only two distinct replacements remain.
                     Self.orrZero,
-                    Self.addZeroToXzr,
-                    Self.subZeroToXzr,
                     Self.andZero,
                 ]
             ),
@@ -77,6 +78,56 @@ final class InstructionSubstitutionTests: XCTestCase {
                 "\(testCase.name) produced unexpected replacement \(String(format: "0x%08X", replacement))"
             )
             XCTAssertNotEqual(replacement, testCase.raw)
+        }
+    }
+
+    func testSPInstructionsAreNeverSubstituted() {
+        // In ADD/SUB immediate, register 31 means SP (not XZR).
+        // These must never be decoded as substitution candidates.
+        let engine = SubstitutionEngine()
+        let spInstructions: [(String, UInt32)] = [
+            ("ADD SP, X29, #0 (MOV SP, X29 epilogue)", 0x910003BF), // ADD SP, X29, #0
+            ("ADD X0, SP, #0 (stack address calc)",     0x910003E0), // ADD X0, SP, #0
+            ("SUB SP, X29, #0",                         0xD10003BF), // SUB SP, X29, #0
+            ("SUB X0, SP, #0",                          0xD10003E0), // SUB X0, SP, #0
+        ]
+
+        for (name, raw) in spInstructions {
+            XCTAssertNil(
+                ARM64Codec.decode(raw),
+                "\(name) (0x\(String(raw, radix: 16))) must not be decoded as a substitution candidate"
+            )
+            var rng = SplitMix64(seed: 42)
+            XCTAssertNil(
+                engine.substitute(for: raw, ratio: 1.0, using: &rng),
+                "\(name) must not be substituted"
+            )
+        }
+    }
+
+    func testNoEffectReplacementsNeverProduceAddSubSP() {
+        // No-effect forms write to register 31 (XZR in logical context).
+        // Replacement options must NOT include ADD/SUB forms where
+        // register 31 would mean SP instead of XZR.
+        let engine = SubstitutionEngine()
+        let nopRaw: UInt32 = 0xD503201F
+
+        // Collect all possible replacement values across many seeds
+        var allReplacements = Set<UInt32>()
+        for seed in UInt64(1)...100 {
+            var rng = SplitMix64(seed: seed)
+            if let replacement = engine.substitute(for: nopRaw, ratio: 1.0, using: &rng) {
+                allReplacements.insert(replacement)
+            }
+        }
+
+        // Verify no replacement is an ADD/SUB immediate (bits 28-24 = 10001)
+        for replacement in allReplacements {
+            let isAddSubImm = (replacement & 0x1F00_0000) == 0x1100_0000
+            XCTAssertFalse(
+                isAddSubImm,
+                String(format: "NOP replacement 0x%08X is ADD/SUB immediate — would write to SP!", replacement)
+            )
         }
     }
 


### PR DESCRIPTION
ARM64 register 31 means XZR in logical-register instructions but SP in ADD/SUB immediate instructions. The substitution engine treated it as XZR uniformly, causing three critical issues:

1. Decoder misidentified ADD/SUB SP,Xn,#0 (e.g. function epilogue MOV SP,X29) as no-effect, allowing replacement with NOP — instant stack corruption.
2. No-effect replacements generated ADD/SUB with dest=31=SP, writing arbitrary values to the stack pointer.
3. Register-copy replacements with source=31 generated ADD/SUB that reads SP instead of zero.

