### PR TITLE
fix: 修复 SDK 6.7 CFF 集成中的 4 个关键缺陷

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/anti_debug_watchdog.c
+++ b/RiskDetectorApp/Sources/CRiskCore/anti_debug_watchdog.c
@@ -347,10 +347,15 @@ static void cprisk_watchdog_run_iteration(void) {
         }
 
         CPR_CFF_CASE(0x18u): {
+            /* Fake state: mix entropy then always resume at 0x12
+             * (exception handler verification).  Must NOT jump to
+             * 0x15 because that skips the detection probes at 0x13
+             * and anomaly aggregation at 0x14, producing a false-
+             * negative snapshot with all-zero detection results. */
             poison_mix ^= ((uint64_t)anomaly_flags << 17u) ^
                           ((uint64_t)(signal_probe != 0) << 9u) ^
                           0x9E3779B97F4A7C15ULL;
-            CPR_CFF_GOTO((poison_mix & 1u) == 0u ? 0x12u : 0x15u);
+            CPR_CFF_GOTO(0x12u);
         }
     CPR_CFF_END();
 }

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_cff.h
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_cff.h
@@ -78,7 +78,8 @@ void cprisk_cff_finalize(cprisk_cff_context_t *context);
         cprisk_cff_context_t cpr_cff_storage_; \
         cprisk_cff_context_t *const cpr_cff_ctx = &cpr_cff_storage_; \
         cprisk_cff_init_default(cpr_cff_ctx, (uint32_t)(seed), (uint32_t)(entry)); \
-        while ((cpr_cff_ctx->iteration_budget--) > 0u) { \
+        while (cpr_cff_ctx->iteration_budget > 0u) { \
+            cpr_cff_ctx->iteration_budget--; \
             const uint32_t cpr_cff_state_ = cprisk_cff_current_state(cpr_cff_ctx); \
             switch (cpr_cff_state_) {
 
@@ -88,7 +89,8 @@ void cprisk_cff_finalize(cprisk_cff_context_t *context);
         cprisk_cff_context_t *const cpr_cff_ctx = &cpr_cff_storage_; \
         cprisk_cff_config_t cpr_cff_config_ = (config_value); \
         cprisk_cff_init(cpr_cff_ctx, &cpr_cff_config_); \
-        while ((cpr_cff_ctx->iteration_budget--) > 0u) { \
+        while (cpr_cff_ctx->iteration_budget > 0u) { \
+            cpr_cff_ctx->iteration_budget--; \
             const uint32_t cpr_cff_state_ = cprisk_cff_current_state(cpr_cff_ctx); \
             switch (cpr_cff_state_) {
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/DecisionTree.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/DecisionTree.swift
@@ -228,7 +228,9 @@ public enum ConditionExpression: Codable, Sendable {
                         sink.store(ConditionExpression.customEvaluatorRegistry.evaluate(id: id, context: context))
                     }
                 default:
-                    encodedState = CFFStateCodec.encode(entryState, seed: seed, salt: salt)
+                    // Terminate on unexpected state to avoid infinite loop
+                    // (resetting to entryState would re-enter the same handler)
+                    sink.store(false)
                 }
             }
         }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskTypes.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskTypes.swift
@@ -85,7 +85,7 @@ public enum InternalRiskLevel: String, Codable, Sendable {
 
     /// 从分数计算风险等级
     public static func from(score: Double) -> InternalRiskLevel {
-        guard score.isFinite else { return .low }
+        guard score.isFinite else { return score > 0 ? .critical : .low }
         guard score >= 0 else { return .low }
         switch score {
         case 0..<30: return .low


### PR DESCRIPTION
ARM64 register 31 means XZR in logical-register instructions but SP in ADD/SUB immediate instructions. The substitution engine treated it as XZR uniformly, causing three critical issues:

1. Decoder misidentified ADD/SUB SP,Xn,#0 (e.g. function epilogue MOV SP,X29) as no-effect, allowing replacement with NOP — instant stack corruption.
2. No-effect replacements generated ADD/SUB with dest=31=SP, writing arbitrary values to the stack pointer.
3. Register-copy replacements with source=31 generated ADD/SUB that reads SP instead of zero.

