### PR TITLE
fix: 修复第三批审查发现的 Mach-O 解析与安全缺陷

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/SDKBinaryIntegrityChecker.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/SDKBinaryIntegrityChecker.swift
@@ -239,6 +239,7 @@ enum SDKBinaryIntegrityChecker {
         var cmd = header.advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
             if loadCmd.cmd == LC_CODE_SIGNATURE {
                 return true
             }
@@ -277,6 +278,7 @@ enum SDKBinaryIntegrityChecker {
         var cmd = header.advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
             if loadCmd.cmd == LC_UUID {
                 let uuidCmd = cmd.assumingMemoryBound(to: uuid_command.self).pointee
                 let bytes = withUnsafeBytes(of: uuidCmd.uuid) { Array($0) }
@@ -294,6 +296,7 @@ enum SDKBinaryIntegrityChecker {
         var cmd = header.advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
             if loadCmd.cmd == LC_SEGMENT_64 {
                 let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                 let segName = withUnsafePointer(to: seg.segname) { ptr in
@@ -321,6 +324,7 @@ enum SDKBinaryIntegrityChecker {
         var cmd = header.advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
             if loadCmd.cmd == LC_SEGMENT_64 {
                 let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                 totalSize += seg.filesize

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/SDKIntegrityChecker.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/SDKIntegrityChecker.swift
@@ -85,6 +85,7 @@ struct SDKIntegrityChecker: Detector {
 
         for _ in 0..<header64.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_CODE_SIGNATURE {
                 return true
             }
@@ -335,6 +336,7 @@ struct PLTIntegrityGuard {
         var cmd = UnsafeRawPointer(ptr).advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_SEGMENT_64 {
                 let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                 if tupleStringEquals(seg.segname, "__TEXT") {
@@ -383,6 +385,7 @@ struct PLTIntegrityGuard {
             var cmd = UnsafeRawPointer(headerPtr).advanced(by: MemoryLayout<mach_header_64>.size)
             for _ in 0..<headerPtr.pointee.ncmds {
                 let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+                guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
                 if load.cmd == LC_UUID {
                     let uuidCmd = cmd.assumingMemoryBound(to: uuid_command.self).pointee
                     let bytes = withUnsafeBytes(of: uuidCmd.uuid) { Array($0) }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/TextSegmentIntegrityChecker.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/TextSegmentIntegrityChecker.swift
@@ -384,6 +384,7 @@ enum TextSegmentIntegrityChecker {
 
         for _ in 0..<ptr.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_SEGMENT_64 {
                 let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                 if tupleStringEquals(seg.segname, "__TEXT") {
@@ -421,6 +422,7 @@ enum TextSegmentIntegrityChecker {
         var cmd = UnsafeRawPointer(ptr).advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_ENCRYPTION_INFO_64 {
                 guard load.cmdsize >= MemoryLayout<encryption_info_command_64>.size else { return false }
                 let enc = cmd.assumingMemoryBound(to: encryption_info_command_64.self).pointee
@@ -527,6 +529,7 @@ enum TextSegmentIntegrityChecker {
         var cmd = UnsafeRawPointer(ptr).advanced(by: MemoryLayout<mach_header_64>.size)
         for _ in 0..<ptr.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_UUID {
                 let uuidCmd = cmd.assumingMemoryBound(to: uuid_command.self).pointee
                 let bytes = withUnsafeBytes(of: uuidCmd.uuid) { Array($0) }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DyldInterposeDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DyldInterposeDetector.swift
@@ -51,6 +51,7 @@ struct DyldInterposeDetector: Detector {
 
             for _ in 0..<header64.pointee.ncmds {
                 let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
+                guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
                 if loadCmd.cmd == LC_SEGMENT_64 {
                     let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                     let segName = withUnsafePointer(to: seg.segname) { ptr in

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaModuleDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaModuleDetector.swift
@@ -210,6 +210,7 @@ struct FridaModuleDetector: Detector {
 
         for _ in 0..<Int(header64.pointee.ncmds) {
             let loadCommand = command.assumingMemoryBound(to: load_command.self).pointee
+            guard loadCommand.cmdsize >= MemoryLayout<load_command>.size else { break }
             defer { command = command.advanced(by: Int(loadCommand.cmdsize)) }
 
             guard loadCommand.cmd == LC_SEGMENT_64 else { continue }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/IndirectSymbolPointerDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/IndirectSymbolPointerDetector.swift
@@ -93,6 +93,7 @@ struct IndirectSymbolPointerDetector: Detector {
                     }
                 }
             }
+            guard lc.cmdsize >= MemoryLayout<load_command>.size else { break }
             cmdPtr = cmdPtr.advanced(by: Int(lc.cmdsize))
         }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/PointerValidationDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/PointerValidationDetector.swift
@@ -122,6 +122,7 @@ enum MachOTextRange {
                     return start..<end
                 }
             }
+            guard lc.cmdsize >= MemoryLayout<load_command>.size else { break }
             cmdPtr = cmdPtr.advanced(by: Int(lc.cmdsize))
         }
         return nil

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Network/CertificatePinningSessionDelegate.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Network/CertificatePinningSessionDelegate.swift
@@ -98,6 +98,7 @@ public final class CertificatePinningSessionDelegate: NSObject, URLSessionDelega
         guard let publicKey = SecCertificateCopyKey(certificate) else { return nil }
         var error: Unmanaged<CFError>?
         guard let publicKeyData = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
+            error?.takeRetainedValue()  // release to avoid leak
             return nil
         }
         let hash = SHA256.hash(data: publicKeyData)

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/ExternalServerAggregateProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/ExternalServerAggregateProvider.swift
@@ -80,6 +80,7 @@ final class ExternalServerAggregateProvider: RiskSignalProvider {
             Logger.log("server_aggregate.setVerified rejected: no key configured")
             return
         }
+        let capturedKey = key
         lock.unlock()
 
         guard let payload = try? JSONEncoder().encode(signals) else {
@@ -87,12 +88,18 @@ final class ExternalServerAggregateProvider: RiskSignalProvider {
             return
         }
 
-        guard HMAC<SHA256>.isValidAuthenticationCode(signature, authenticating: payload, using: key) else {
+        guard HMAC<SHA256>.isValidAuthenticationCode(signature, authenticating: payload, using: capturedKey) else {
             Logger.log("server_aggregate.setVerified rejected: HMAC mismatch")
             return
         }
 
         lock.lock()
+        // Re-check key hasn't been cleared between verification and store
+        guard serverSignalKey != nil else {
+            lock.unlock()
+            Logger.log("server_aggregate.setVerified rejected: key cleared during verification")
+            return
+        }
         current = signals
         lock.unlock()
         Logger.log("server_aggregate.setVerified: accepted")

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/CallStackUnwinder.swift
@@ -210,6 +210,7 @@ public enum CallStackUnwinder {
 
         for _ in 0..<ptr.pointee.ncmds {
             let load = cmd.assumingMemoryBound(to: load_command.self).pointee
+            guard load.cmdsize >= MemoryLayout<load_command>.size else { break }
             if load.cmd == LC_SEGMENT_64 {
                 let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                 if tupleStringEquals(seg.segname, "__TEXT") {


### PR DESCRIPTION
全局 Mach-O load command 遍历安全加固（10 个文件）:
- 所有 Mach-O 解析循环均添加 cmdsize >= sizeof(load_command) 守卫， 防止 cmdsize==0 导致无限循环或 cmdsize 畸形导致越界读取
- 涉及: CallStackUnwinder, SDKBinaryIntegrityChecker, SDKIntegrityChecker, TextSegmentIntegrityChecker, DyldInterposeDetector, FridaModuleDetector, PointerValidationDetector, IndirectSymbolPointerDetector

CertificatePinningSessionDelegate.swift:
- spkiSHA256() 中 SecKeyCopyExternalRepresentation 失败时 未释放 Unmanaged<CFError>，导致 CFError 对象泄漏

ExternalServerAggregateProvider.swift:
- setVerified() TOCTOU 竞态: serverSignalKey 在 unlock 后 可能被其他线程清除，导致用已失效 key 验证的数据被存入 current； 增加 re-check guard 确保 key 仍然有效
