### PR TITLE
fix: 修复第四批审查发现的 10 个安全与逻辑缺陷

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/TemporalAnalyzer.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/TemporalAnalyzer.swift
@@ -110,7 +110,7 @@ public struct TimeWindow: Sendable, Codable {
     /// 检查给定时间戳是否在窗口内
     public func contains(_ timestamp: TimeInterval) -> Bool {
         let (start, end) = getActualRange()
-        return timestamp >= start && timestamp <= end
+        return timestamp >= start && timestamp < end
     }
 }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Behavior/TouchCapture.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Behavior/TouchCapture.swift
@@ -229,7 +229,7 @@ private enum TouchMath {
         guard intervals.count >= 2 else { return nil }
         let mean = intervals.reduce(0, +) / Double(intervals.count)
         guard mean > 0 else { return nil }
-        let variance = intervals.map { pow($0 - mean, 2) }.reduce(0, +) / Double(intervals.count)
+        let variance = intervals.map { pow($0 - mean, 2) }.reduce(0, +) / Double(intervals.count - 1)
         let std = sqrt(variance)
         return std / mean
     }
@@ -257,7 +257,7 @@ private enum TouchMath {
         guard values.count >= 3 else { return nil }
         let mean = values.reduce(0, +) / Double(values.count)
         guard mean > 0 else { return nil }
-        let variance = values.map { pow($0 - mean, 2) }.reduce(0, +) / Double(values.count)
+        let variance = values.map { pow($0 - mean, 2) }.reduce(0, +) / Double(values.count - 1)
         return sqrt(variance) / mean
     }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/ScenarioPolicy.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/ScenarioPolicy.swift
@@ -51,7 +51,7 @@ public struct ScenarioPolicy: Codable, Sendable {
         var m = try container.decodeIfPresent(Double.self, forKey: .mediumThreshold) ?? 30
         var h = try container.decodeIfPresent(Double.self, forKey: .highThreshold) ?? 55
         var c = try container.decodeIfPresent(Double.self, forKey: .criticalThreshold) ?? 80
-        if !m.isFinite || !h.isFinite || !c.isFinite || !(0 <= m && m <= h && h <= c && c <= 100) {
+        if !m.isFinite || !h.isFinite || !c.isFinite || !(0 <= m && m < h && h < c && c <= 100) {
             m = 30; h = 55; c = 80
         }
         mediumThreshold = m

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/PhysicalSensorProbe.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/PhysicalSensorProbe.swift
@@ -270,6 +270,11 @@ struct PhysicalSensorProbe: Detector {
 
         // 磁力计：总场强 0 或不在 25-65 μT -> +15
         let magMagnitudes = mSamples.map { sqrt($0.x * $0.x + $0.y * $0.y + $0.z * $0.z) }
+        guard !magMagnitudes.isEmpty else {
+            score += 15
+            methods.append("physical_sensor:magnetometer_no_samples")
+            return (score, methods)
+        }
         let magMean = magMagnitudes.reduce(0, +) / Double(magMagnitudes.count)
         if magMean < 0.1 {
             score += 15

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/RWXMemoryScanner.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/RWXMemoryScanner.swift
@@ -184,8 +184,8 @@ struct RWXMemoryScanner: Detector {
                 }
             }
 
-            address += size
             if size == 0 { break }
+            address += size
             iteration += 1
         }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/SystemLibrarySegmentLayoutDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/SystemLibrarySegmentLayoutDetector.swift
@@ -288,6 +288,7 @@ private extension SystemLibrarySegmentLayoutDetector {
 
             let regionStart = UInt64(address)
             let regionEnd = regionStart &+ UInt64(size)
+            guard regionEnd >= regionStart else { break }
             if regionStart >= imageEnd {
                 break
             }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/CapabilityProbeEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/CapabilityProbeEngine.swift
@@ -85,7 +85,7 @@ public struct CapabilityScore: Codable, Sendable {
             ],
             state: RiskSignalState.soft(confidence: confidence),
             layer: 3,
-            weightHint: Double(riskContribution) / 100.0
+            weightHint: min(Double(riskContribution), 100)
         )
     }
 }

--- a/cprisk-armor/Sources/MachOKit/MachOFile.swift
+++ b/cprisk-armor/Sources/MachOKit/MachOFile.swift
@@ -774,7 +774,8 @@ public final class MachOFile {
         var cursor = segStart
         for range in occupied {
             guard let aligned = try? alignUp(cursor, to: alignment) else { return nil }
-            if aligned + contentLength <= range.start {
+            guard let alignedEnd = try? checkedAdd(aligned, contentLength, context: "findAvailableRange gap check") else { return nil }
+            if alignedEnd <= range.start {
                 let delta = aligned - segStart
                 return (aligned, segment.vmAddress + UInt64(delta))
             }
@@ -782,7 +783,8 @@ public final class MachOFile {
         }
 
         guard let alignedTail = try? alignUp(cursor, to: alignment) else { return nil }
-        if alignedTail + contentLength <= segEnd {
+        guard let tailEnd = try? checkedAdd(alignedTail, contentLength, context: "findAvailableRange tail check") else { return nil }
+        if tailEnd <= segEnd {
             let delta = alignedTail - segStart
             return (alignedTail, segment.vmAddress + UInt64(delta))
         }


### PR DESCRIPTION
1. PhysicalSensorProbe: 磁力计样本为空时除零崩溃
2. TouchCapture.intervalCoefficientOfVariation: 方差公式使用总体方差而非样本方差，与同文件 variance() 不一致
3. TouchCapture.coefficientOfVariation: 同上，方差公式不一致
4. MachOFile.findAvailableRange: gap 检查 aligned+contentLength 未使用 checkedAdd 导致整数溢出
5. MachOFile.findAvailableRange: tail 检查 alignedTail+contentLength 同上溢出风险
6. SystemLibrarySegmentLayoutDetector: regionEnd 使用 &+ 包装加法后未检查回绕
7. TemporalAnalyzer.TimeWindow.contains: 闭区间 <= end 应改为半开区间 < end
8. ScenarioPolicy.init(from:): 阈值验证允许 m==h==c 导致退化风险等级
9. CapabilityProbeEngine: weightHint 使用 0-1 刻度，与全代码库 0-100 惯例不一致
10. RWXMemoryScanner: size==0 检查在 address+=size 之后，导致零步长时地址未推进即跳过

