### PR TITLE
fix: 修复第七批审查发现的 10 个安全与逻辑缺陷

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Config/ConfigSignatureVerifier.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Config/ConfigSignatureVerifier.swift
@@ -220,7 +220,7 @@ public enum ConfigSignatureVerifier {
 extension Data {
     init?(hexString: String) {
         let hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard hex.count.isMultiple(of: 2) else { return nil }
+        guard !hex.isEmpty, hex.count.isMultiple(of: 2) else { return nil }
         var data = Data(capacity: hex.count / 2)
         var index = hex.startIndex
         while index < hex.endIndex {

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Decision/RiskDetectionEngine.swift
@@ -922,7 +922,7 @@ public struct RiskDetectionEngine: Sendable {
                     }
                 case .tampered:
                     tamperedCount += 1
-                    softScore += tamperedBase
+                    softScore += max(tamperedBase, weight)
                 case .serverRequired, .unavailable:
                     break
                 }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DyldInterposeDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DyldInterposeDetector.swift
@@ -49,9 +49,12 @@ struct DyldInterposeDetector: Detector {
             let header64 = ptr.assumingMemoryBound(to: mach_header_64.self)
             var cmd = ptr.advanced(by: MemoryLayout<mach_header_64>.size)
 
+            let commandLimit = ptr.advanced(by: MemoryLayout<mach_header_64>.size + Int(header64.pointee.sizeofcmds))
             for _ in 0..<header64.pointee.ncmds {
+                guard cmd + MemoryLayout<load_command>.size <= commandLimit else { break }
                 let loadCmd = cmd.assumingMemoryBound(to: load_command.self).pointee
-                guard loadCmd.cmdsize >= MemoryLayout<load_command>.size else { break }
+                guard loadCmd.cmdsize >= MemoryLayout<load_command>.size,
+                      cmd + Int(loadCmd.cmdsize) <= commandLimit else { break }
                 if loadCmd.cmd == LC_SEGMENT_64 {
                     let seg = cmd.assumingMemoryBound(to: segment_command_64.self).pointee
                     let segName = withUnsafePointer(to: seg.segname) { ptr in

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaModuleDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaModuleDetector.swift
@@ -243,7 +243,8 @@ struct FridaModuleDetector: Detector {
         let runtimeAddress = Int64(section.addr) + slide
         guard byteCount > 0,
               runtimeAddress > 0,
-              let base = UnsafeRawPointer(bitPattern: UInt(truncatingIfNeeded: runtimeAddress)) else {
+              runtimeAddress <= Int64(UInt.max),
+              let base = UnsafeRawPointer(bitPattern: UInt(runtimeAddress)) else {
             return nil
         }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/IMUNoiseSpectrumProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/IMUNoiseSpectrumProvider.swift
@@ -197,7 +197,11 @@ final class IMUNoiseSpectrumProvider: RiskSignalProvider {
         let highFreq = Array(spectrum.suffix(spectrum.count / 4))
         guard !highFreq.isEmpty else { return -100 }
         let sorted = highFreq.sorted()
-        return sorted[sorted.count / 2]
+        let mid = sorted.count / 2
+        if sorted.count % 2 == 0 {
+            return (sorted[mid - 1] + sorted[mid]) / 2.0
+        }
+        return sorted[mid]
     }
 }
 #else

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/MountPointProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Providers/MountPointProvider.swift
@@ -62,8 +62,8 @@ final class MountPointProvider: RiskSignalProvider {
         var hitVirtualFS: String?
         let mountCount = Int(count)
 
-        for i in 0..<count {
-            let stat = buf[Int(i)]
+        for i in 0..<mountCount {
+            let stat = buf[i]
             let fsType = extractCString(from: stat.f_fstypename)
             let mnton = extractCString(from: stat.f_mntonname)
             let fsLower = fsType.lowercased()

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Storage/FreshnessAnchor.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Storage/FreshnessAnchor.swift
@@ -89,6 +89,9 @@ final class FreshnessAnchor {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
-        SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            Logger.log("FreshnessAnchor: SecItemDelete failed with status \(status)")
+        }
     }
 }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Storage/RiskHistoryStore.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Storage/RiskHistoryStore.swift
@@ -191,11 +191,12 @@ public final class RiskHistoryStore {
             return LoadedState(events: [], freshness: anchor)
         }
 
-        if state.freshness.sequence > anchor.sequence || state.freshness.latestTimestamp > anchor.latestTimestamp {
-            _ = freshnessAnchor.write(state.freshness)
+        let merged = maxFreshness(anchor, state.freshness)
+        if merged.sequence > anchor.sequence || merged.latestTimestamp > anchor.latestTimestamp {
+            _ = freshnessAnchor.write(merged)
         }
 
-        return LoadedState(events: state.events, freshness: maxFreshness(anchor, state.freshness))
+        return LoadedState(events: state.events, freshness: merged)
     }
 
     private func saveLocked(_ state: LoadedState) {

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SVCDirectCall.swift
@@ -143,16 +143,14 @@ enum SVCDirectCall {
             if cprisk_sysctlbyname_direct(cName, nil, &size, nil, 0, &rawErrno) != 0 || size == 0 {
                 return nil
             }
-            var buf = [CChar](repeating: 0, count: max(1, Int(size)))
+            var buf = [CChar](repeating: 0, count: max(1, Int(size) + 1))
             let result = buf.withUnsafeMutableBufferPointer { buffer in
                 cprisk_sysctlbyname_direct(cName, buffer.baseAddress, &size, nil, 0, &rawErrno)
             }
-            if result != 0 || size == 0 || Int(size) > buf.count {
+            if result != 0 || size == 0 || Int(size) >= buf.count {
                 return nil
             }
-            if buf[Int(size) - 1] != 0 {
-                buf.append(0)
-            }
+            buf[Int(size)] = 0
             return String(cString: buf)
         }
     }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SignalCompressor.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SignalCompressor.swift
@@ -35,15 +35,16 @@ public enum SignalCompressor {
         let (crossLayer, extendedByte) = crossLayerBits(signals: signals)
 
         let digest = SecureBuffer(size: 9).use { ptr in
-            ptr.assumingMemoryBound(to: UInt8.self)[0] = layer1
-            ptr.assumingMemoryBound(to: UInt8.self)[1] = layer2
-            ptr.assumingMemoryBound(to: UInt8.self)[2] = layer3
-            ptr.assumingMemoryBound(to: UInt8.self)[3] = layer4
-            ptr.assumingMemoryBound(to: UInt8.self)[4] = UInt8((crossLayer >> 24) & 0xFF)
-            ptr.assumingMemoryBound(to: UInt8.self)[5] = UInt8((crossLayer >> 16) & 0xFF)
-            ptr.assumingMemoryBound(to: UInt8.self)[6] = UInt8((crossLayer >> 8) & 0xFF)
-            ptr.assumingMemoryBound(to: UInt8.self)[7] = UInt8(crossLayer & 0xFF)
-            ptr.assumingMemoryBound(to: UInt8.self)[8] = extendedByte
+            let bytes = ptr.assumingMemoryBound(to: UInt8.self)
+            bytes[0] = layer1
+            bytes[1] = layer2
+            bytes[2] = layer3
+            bytes[3] = layer4
+            bytes[4] = UInt8((crossLayer >> 24) & 0xFF)
+            bytes[5] = UInt8((crossLayer >> 16) & 0xFF)
+            bytes[6] = UInt8((crossLayer >> 8) & 0xFF)
+            bytes[7] = UInt8(crossLayer & 0xFF)
+            bytes[8] = extendedByte
             return Data(bytes: ptr, count: 9)
         }
 


### PR DESCRIPTION
1. ConfigSignatureVerifier: 空白 hex 字符串绕过校验（0 是 2 的倍数）
2. RiskHistoryStore: freshness 锚点更新直接写 state 而非 merged max， 允许时间戳回滚攻击
3. IMUNoiseSpectrumProvider: 偶数长度数组中位数计算错误（未取平均值）
4. DyldInterposeDetector: load command 迭代缺少边界检查， 恶意 Mach-O 可导致越界读取
5. SVCDirectCall: 缓冲区未预留 null 终止符额外字节
6. FridaModuleDetector: UInt(truncatingIfNeeded:) 不安全指针构造， 改为带范围检查的 UInt()
7. MountPointProvider: mountCount 声明但未使用，循环直接用 Int32 count
8. RiskDetectionEngine: .tampered 状态使用固定 tamperedBase 忽略信号权重， 改为 max(tamperedBase, weight)
9. FreshnessAnchor: SecItemDelete 返回值被丢弃，增加错误日志
10. SignalCompressor: 重复 assumingMemoryBound 调用，提取单次绑定