### PR TITLE
fix: 12 bugs from review of previous commit and newly reviewed Swift …

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_anti_dump_probe.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_anti_dump_probe.c
@@ -77,6 +77,8 @@ static int cprisk_scan_vm_regions(void) {
         /* Shared+write mappings are suspicious for injected dump channels.
          * Plain read-only shared mappings are common for normal dylibs. */
         if (info.shared && (info.protection & VM_PROT_WRITE)) {
+            if (obj_name != MACH_PORT_NULL)
+                mach_port_deallocate(mach_task_self(), obj_name);
             return -1;
         }
 
@@ -87,6 +89,8 @@ static int cprisk_scan_vm_regions(void) {
             (info.protection & VM_PROT_WRITE)) {
             /* Also require that the region is not in a system framework bundle,
              * which legitimately uses JIT for JavaScriptCore/WebKit. */
+            if (obj_name != MACH_PORT_NULL)
+                mach_port_deallocate(mach_task_self(), obj_name);
             return -1;
         }
 

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_data_loader.c
@@ -145,8 +145,10 @@ static void cprisk_keystream_at_l(const uint8_t *key, uint32_t sid,
                                   const uint8_t *nonce, size_t nonce_len,
                                   size_t byte_offset,
                                   uint8_t *out, size_t len) {
-    if (nonce_len > CPRISK_ARMOR_NONCE_SIZE)
+    if (nonce_len > CPRISK_ARMOR_NONCE_SIZE) {
+        if (len > 0) memset(out, 0, len);
         return;
+    }
     if (len == 0)
         return;
 
@@ -222,8 +224,10 @@ void cprisk_armor_derive_chained_key(
     uint8_t out_key[CPRISK_ARMOR_KEY_SIZE]
 ) {
     /* Level 1: HMAC(parent, index || nonce) */
-    if (nonce_len > CPRISK_ARMOR_NONCE_SIZE)
+    if (nonce_len > CPRISK_ARMOR_NONCE_SIZE) {
+        memset(out_key, 0, CPRISK_ARMOR_KEY_SIZE);
         return;
+    }
     uint8_t chain_material[4 + CPRISK_ARMOR_NONCE_SIZE];
     chain_material[0] = (uint8_t)(section_index);
     chain_material[1] = (uint8_t)(section_index >> 8);

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_signal_probe.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_signal_probe.c
@@ -727,6 +727,9 @@ int cprisk_detect_thread_exception_ports(void) {
         }
     }
 
+    for (mach_msg_type_number_t i = 0; i < thread_count; i++) {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
     vm_deallocate(mach_task_self(),
                   (vm_address_t)threads,
                   sizeof(thread_act_t) * thread_count);
@@ -762,6 +765,9 @@ int cprisk_detect_hardware_breakpoints(void) {
         }
     }
 
+    for (mach_msg_type_number_t i = 0; i < thread_count; i++) {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
     vm_deallocate(mach_task_self(),
                   (vm_address_t)threads,
                   sizeof(thread_act_t) * thread_count);
@@ -1379,6 +1385,9 @@ int cprisk_detect_suspicious_threads(void) {
         }
     }
 
+    for (mach_msg_type_number_t i = 0; i < thread_count; i++) {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
     vm_deallocate(mach_task_self(),
                   (vm_address_t)threads,
                   sizeof(thread_act_t) * thread_count);

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/AnomalyDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Analysis/AnomalyDetector.swift
@@ -444,7 +444,7 @@ private func sqrt(_ x: Double) -> Double {
 private func interpolatedPercentile(sorted: [Double], p: Double) -> Double {
     guard !sorted.isEmpty else { return 0 }
     let n = Double(sorted.count)
-    let index = max(0, min((p * n) - 0.5, n - 1))
+    let index = max(0, min(p * (n - 1), n - 1))
     let lower = Int(Darwin.floor(index))
     let upper = Int(Darwin.ceil(index))
     guard lower >= 0, upper < sorted.count else { return sorted[max(0, min(lower, sorted.count - 1))] }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Config/RemoteConfigProvider.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Config/RemoteConfigProvider.swift
@@ -338,22 +338,26 @@ public final class RemoteConfigProvider: @unchecked Sendable {
 
         let schedule: () -> Void = { [weak self] in
             guard let self else { return }
-            self.lock.withLock {
+            let shouldCreate: Bool = self.lock.withLock {
                 // 二次检查：确保 Timer 仍未被创建（防止两次 async 同时执行）
-                guard self.timer == nil else { return }
-                let t = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-                    guard let self else { return }
-                    self.fetchLatest { result in
-                        if case .failure(let error) = result {
-                            Logger.log("remote_config.periodic_update failed: \(error.localizedDescription)")
-                            if self.isConfigStale {
-                                Logger.log("remote_config: config is stale (age=\(Int(self.configAge))s), falling back to default")
-                                self.reloadCachedConfigTrustState()
-                            }
+                guard self.timer == nil else { return false }
+                return true
+            }
+            guard shouldCreate else { return }
+            let t = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                self.fetchLatest { result in
+                    if case .failure(let error) = result {
+                        Logger.log("remote_config.periodic_update failed: \(error.localizedDescription)")
+                        if self.isConfigStale {
+                            Logger.log("remote_config: config is stale (age=\(Int(self.configAge))s), falling back to default")
+                            self.reloadCachedConfigTrustState()
                         }
                     }
                 }
-                RunLoop.main.add(t, forMode: .common)
+            }
+            RunLoop.main.add(t, forMode: .common)
+            self.lock.withLock {
                 self.timer = t
                 self._schedulingTimer = false
             }

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/RuntimeIntegrityValidator.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiBypass/RuntimeIntegrityValidator.swift
@@ -191,10 +191,30 @@ struct RuntimeIntegrityValidator: Detector {
     /// - Branch register `BR Xn`: fixed encoding 0xD61F0000 | (Rn << 5)
     /// - `BRK #imm16`: top 8 bits = 0xD4, bits [23:21] = 001, bit 0 = 0
     /// - `LDR Xn, #+8` followed by `BR Xn` (trampoline pattern)
+    private func safeReadInstruction(at address: UnsafeRawPointer) -> UInt32? {
+        var instruction: UInt32 = 0
+        var outSize: mach_vm_size_t = 0
+        let kr = withUnsafeMutablePointer(to: &instruction) { ptr in
+            vm_read_overwrite(
+                mach_task_self_,
+                vm_address_t(UInt(bitPattern: address)),
+                vm_size_t(MemoryLayout<UInt32>.size),
+                vm_address_t(UInt(bitPattern: ptr)),
+                &outSize
+            )
+        }
+        guard kr == KERN_SUCCESS, outSize == mach_vm_size_t(MemoryLayout<UInt32>.size) else {
+            return nil
+        }
+        return instruction
+    }
+
     private func detectInlineHookAtAddress(_ address: UnsafeRawPointer) -> Bool {
-        // Read first two instructions (8 bytes)
-        let instruction0 = address.assumingMemoryBound(to: UInt32.self).pointee
-        let instruction1 = address.advanced(by: 4).assumingMemoryBound(to: UInt32.self).pointee
+        // Read first two instructions safely via vm_read_overwrite to avoid EXC_BAD_ACCESS
+        guard let instruction0 = safeReadInstruction(at: address),
+              let instruction1 = safeReadInstruction(at: address.advanced(by: 4)) else {
+            return false
+        }
 
         // Check for unconditional branch: B imm26
         // Encoding: [31:26] = 000101

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/FridaDetector.swift
@@ -233,19 +233,19 @@ struct FridaDetector: Detector {
             probe.withCString { cstr in
                 _ = send(fd, cstr, strlen(cstr), 0)
             }
+            guard waitReadable(fd, timeoutMs: timeoutMs) else { continue }
+
+            var buffer = [UInt8](repeating: 0, count: 160)
+            let readCount = recv(fd, &buffer, buffer.count, 0)
+            guard readCount > 0 else { continue }
+
+            let response = String(decoding: buffer.prefix(Int(readCount)), as: UTF8.self).lowercased()
+            if response.contains("frida") { return "frida" }
+            if response.contains("gum") { return "gum" }
+            if response.contains("re.frida") { return "re.frida" }
+            if response.contains("dbus") { return "dbus" }
+            if response.contains("auth") && response.contains("reject") { return "dbus_auth" }
         }
-        guard waitReadable(fd, timeoutMs: timeoutMs) else { return nil }
-
-        var buffer = [UInt8](repeating: 0, count: 160)
-        let readCount = recv(fd, &buffer, buffer.count, 0)
-        guard readCount > 0 else { return nil }
-
-        let response = String(decoding: buffer.prefix(Int(readCount)), as: UTF8.self).lowercased()
-        if response.contains("frida") { return "frida" }
-        if response.contains("gum") { return "gum" }
-        if response.contains("re.frida") { return "re.frida" }
-        if response.contains("dbus") { return "dbus" }
-        if response.contains("auth") && response.contains("reject") { return "dbus_auth" }
         return nil
     }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Network/CertificatePinningSessionDelegate.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Network/CertificatePinningSessionDelegate.swift
@@ -96,16 +96,30 @@ public final class CertificatePinningSessionDelegate: NSObject, URLSessionDelega
     // ASN.1 SPKI headers for wrapping raw key bytes into DER SubjectPublicKeyInfo.
     // Required so that SHA-256 hashes match those produced by standard tooling
     // (e.g. `openssl x509 -pubkey | openssl pkey -pubin -outform der | sha256`).
-    private static let rsaSPKIHeader: [UInt8] = [
+    // RSA-2048: PKCS#1 key data is 270 bytes
+    private static let rsa2048SPKIHeader: [UInt8] = [
         0x30, 0x82, 0x01, 0x22, 0x30, 0x0D, 0x06, 0x09,
         0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01,
         0x01, 0x05, 0x00, 0x03, 0x82, 0x01, 0x0F, 0x00
     ]
+    // RSA-4096: PKCS#1 key data is 526 bytes
+    private static let rsa4096SPKIHeader: [UInt8] = [
+        0x30, 0x82, 0x02, 0x22, 0x30, 0x0D, 0x06, 0x09,
+        0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01,
+        0x01, 0x05, 0x00, 0x03, 0x82, 0x02, 0x0F, 0x00
+    ]
+    // EC P-256: uncompressed point is 65 bytes
     private static let ecP256SPKIHeader: [UInt8] = [
         0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2A, 0x86,
         0x48, 0xCE, 0x3D, 0x02, 0x01, 0x06, 0x08, 0x2A,
         0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07, 0x03,
         0x42, 0x00
+    ]
+    // EC P-384: uncompressed point is 97 bytes
+    private static let ecP384SPKIHeader: [UInt8] = [
+        0x30, 0x76, 0x30, 0x10, 0x06, 0x07, 0x2A, 0x86,
+        0x48, 0xCE, 0x3D, 0x02, 0x01, 0x06, 0x05, 0x2B,
+        0x81, 0x04, 0x00, 0x22, 0x03, 0x62, 0x00
     ]
 
     /// Extract SPKI SHA-256 hash from a certificate
@@ -119,13 +133,26 @@ public final class CertificatePinningSessionDelegate: NSObject, URLSessionDelega
 
         // Determine the appropriate SPKI header based on key type and size
         let header: [UInt8]
-        if let keyType = SecKeyCopyAttributes(publicKey) as? [CFString: Any],
-           let type = keyType[kSecAttrKeyType] as? String {
-            if type == (kSecAttrKeyTypeRSA as String), publicKeyData.count == 270 {
-                header = Self.rsaSPKIHeader
-            } else if type == (kSecAttrKeyTypeECSECPrimeRandom as String), publicKeyData.count == 65 {
-                header = Self.ecP256SPKIHeader
+        if let attrs = SecKeyCopyAttributes(publicKey) as? [CFString: Any],
+           let type = attrs[kSecAttrKeyType] as? String {
+            if type == (kSecAttrKeyTypeRSA as String) {
+                switch publicKeyData.count {
+                case 270: header = Self.rsa2048SPKIHeader
+                case 526: header = Self.rsa4096SPKIHeader
+                default:
+                    Logger.log("spkiSHA256: unsupported RSA key size \(publicKeyData.count) bytes")
+                    header = []
+                }
+            } else if type == (kSecAttrKeyTypeECSECPrimeRandom as String) {
+                switch publicKeyData.count {
+                case 65: header = Self.ecP256SPKIHeader
+                case 97: header = Self.ecP384SPKIHeader
+                default:
+                    Logger.log("spkiSHA256: unsupported EC key size \(publicKeyData.count) bytes")
+                    header = []
+                }
             } else {
+                Logger.log("spkiSHA256: unsupported key type")
                 header = []
             }
         } else {

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskScorer.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/RiskScorer.swift
@@ -127,7 +127,7 @@ enum RiskScorer {
         let isHighRisk = (total >= config.threshold) || context.jailbreak.isJailbroken
         if context.jailbreak.isJailbroken, total < config.threshold {
             // Hard verdict: jailbreak => at least threshold.
-            total = config.threshold
+            total = min(config.threshold, scoreCap)
         }
         #if DEBUG
         Logger.log("score total=\(total) threshold=\(config.threshold) isHighRisk=\(isHighRisk)")

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SecureBuffer.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SecureBuffer.swift
@@ -57,10 +57,14 @@ final class SecureString {
     /// 常量时间比较，避免通过时序泄露
     func secureCompare(with other: String) -> Bool {
         let otherBytes = Array(other.utf8)
-        guard bytes.count == otherBytes.count else { return false }
-        var acc: UInt8 = 0
-        for i in 0..<bytes.count {
-            acc |= bytes[i] ^ otherBytes[i]
+        let maxLen = max(bytes.count, otherBytes.count)
+        guard maxLen > 0 else { return bytes.count == otherBytes.count }
+        // Fold length mismatch into accumulator to avoid early-return timing leak
+        var acc: UInt8 = bytes.count == otherBytes.count ? 0 : 1
+        for i in 0..<maxLen {
+            let a: UInt8 = i < bytes.count ? bytes[i] : 0
+            let b: UInt8 = i < otherBytes.count ? otherBytes[i] : 0
+            acc |= a ^ b
         }
         return acc == 0
     }
@@ -98,8 +102,11 @@ enum SecureScope {
     static func withSecureValue<T>(_ value: String, _ body: (String) -> T) -> T {
         var bytes = Array(value.utf8)
         defer { secureZero(&bytes) }
-        let str = String(bytes: bytes, encoding: .utf8) ?? ""
-        return body(str)
+        let result = bytes.withUnsafeBufferPointer { buf -> T in
+            let str = String(decoding: buf, as: UTF8.self)
+            return body(str)
+        }
+        return result
     }
 
     static func withSecureBytes<T>(_ bytes: [UInt8], _ body: (UnsafeBufferPointer<UInt8>) -> T) -> T {


### PR DESCRIPTION
…files

Bugs introduced by previous fixes (3):
- obj_name Mach port leaked on early return paths in cprisk_scan_vm_regions
- out_key/out buffer left uninitialized on nonce_len validation failure (cprisk_data_loader.c)
- Thread port send-right leaks in 3 more task_threads callers (cprisk_signal_probe.c)

New bugs found in Swift code (9):
- RiskScorer: score can exceed scoreCap after jailbreak hard verdict bump
- AnomalyDetector: percentile formula p*n-0.5 incorrect, should be p*(n-1) per numpy linear
- RuntimeIntegrityValidator: unsafe raw pointer dereference without readability check (crash risk)
- FridaDetector: all 3 probes sent on same TCP connection before single read (garbled responses)
- RemoteConfigProvider: Timer scheduled inside non-reentrant UnfairLock (potential deadlock)
- CertificatePinningSessionDelegate: add RSA-4096 and EC P-384 SPKI headers + log unknown types
- SecureBuffer: secureCompare early return on length mismatch leaks timing info
- SecureBuffer: SecureScope.withSecureValue creates unzeroed String copy on heap

