### PR TITLE
refactor: deduplicate timingSafeCompare + fix ChallengeTrigger timing…

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Challenge/ChallengeSession.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Challenge/ChallengeSession.swift
@@ -420,19 +420,6 @@ extension ChallengeSession {
         return nil
     }
 
-    private func timingSafeCompare(_ lhs: String, _ rhs: String) -> Bool {
-        let lhsBytes = Array(lhs.utf8)
-        let rhsBytes = Array(rhs.utf8)
-        var result: UInt8 = lhsBytes.count == rhsBytes.count ? 0 : 1
-        let maxCount = max(lhsBytes.count, rhsBytes.count)
-        let lhsN = max(lhsBytes.count, 1)
-        let rhsN = max(rhsBytes.count, 1)
-        for i in 0..<maxCount {
-            result |= lhsBytes[i % lhsN] ^ rhsBytes[i % rhsN]
-        }
-        return result == 0
-    }
-
     private func makeMismatchSignal(challengeId: String, reason: String) -> RiskSignal {
         RiskSignal(
             id: "challenge_hmac_mismatch",

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/KernelHookSideChannel.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/KernelHookSideChannel.swift
@@ -3,7 +3,7 @@ import Darwin
 import Foundation
 
 struct KernelHookSideChannel: Detector {
-    private static var timebaseInfo: mach_timebase_info_data_t = {
+    private static let timebaseInfo: mach_timebase_info_data_t = {
         var info = mach_timebase_info_data_t()
         mach_timebase_info(&info)
         return info

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/TimingRatioBaseline.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/TimingRatioBaseline.swift
@@ -13,7 +13,7 @@ struct TimingRatioBaseline {
         let isAnomalous: Bool
     }
 
-    private static var timebaseInfo: mach_timebase_info_data_t = {
+    private static let timebaseInfo: mach_timebase_info_data_t = {
         var info = mach_timebase_info_data_t()
         mach_timebase_info(&info)
         return info

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/ChallengeTrigger.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/ChallengeTrigger.swift
@@ -495,17 +495,6 @@ extension ChallengeTrigger {
         return timingSafeCompare(expected, signature.lowercased())
     }
 
-    private static func timingSafeCompare(_ lhs: String, _ rhs: String) -> Bool {
-        guard lhs.count == rhs.count else { return false }
-        let lhsBytes = Array(lhs.utf8)
-        let rhsBytes = Array(rhs.utf8)
-        var result: UInt8 = 0
-        for i in 0..<lhsBytes.count {
-            result |= lhsBytes[i] ^ rhsBytes[i]
-        }
-        return result == 0
-    }
-
     /// 验证客户端上报的数据是否与服务端规则匹配
     ///
     /// - Parameters:

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/ReportEnvelope.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Risk/ReportEnvelope.swift
@@ -869,20 +869,6 @@ public struct ReportEnvelope: Codable, Sendable {
         return (digest != nil, version, digest)
     }
 
-    private func timingSafeCompare(_ lhs: String, _ rhs: String) -> Bool {
-        let lhsBytes = Array(lhs.utf8)
-        let rhsBytes = Array(rhs.utf8)
-        // 必须比较字节数而非字符数，否则多字节字符会导致越界崩溃
-        var result: UInt8 = lhsBytes.count == rhsBytes.count ? 0 : 1
-        let maxCount = max(lhsBytes.count, rhsBytes.count)
-        let lhsN = max(lhsBytes.count, 1)
-        let rhsN = max(rhsBytes.count, 1)
-        for i in 0..<maxCount {
-            result |= lhsBytes[i % lhsN] ^ rhsBytes[i % rhsN]
-        }
-
-        return result == 0
-    }
 }
 
 // MARK: - Replay Protection

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SecureBuffer.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/SecureBuffer.swift
@@ -85,6 +85,23 @@ private func secureZero(_ buffer: inout [UInt8]) {
 }
 
 internal func secureZeroBytes(_ buffer: inout [UInt8]) {
+
+/// 常量时间字符串比较。迭代次数固定为 max(lhs, rhs) 字节，
+/// 长度差异编码到累加器中但不提前返回，避免通过执行时间泄露长度信息。
+internal func timingSafeCompare(_ lhs: String, _ rhs: String) -> Bool {
+    let lhsBytes = Array(lhs.utf8)
+    let rhsBytes = Array(rhs.utf8)
+    var result: UInt8 = lhsBytes.count == rhsBytes.count ? 0 : 1
+    let maxCount = max(lhsBytes.count, rhsBytes.count)
+    let lhsN = max(lhsBytes.count, 1)
+    let rhsN = max(rhsBytes.count, 1)
+    for i in 0..<maxCount {
+        result |= lhsBytes[i % lhsN] ^ rhsBytes[i % rhsN]
+    }
+    return result == 0
+}
+
+internal func secureZeroBytes(_ buffer: inout [UInt8]) {
     buffer.withUnsafeMutableBytes { ptr in
         guard let base = ptr.baseAddress else { return }
         memset_s(base, ptr.count, 0, ptr.count)


### PR DESCRIPTION
… leak

Extract a shared timingSafeCompare() free function in SecureBuffer.swift and remove 3 duplicate private implementations:
- ChallengeSession.timingSafeCompare (was fixed but duplicated)
- ReportEnvelope.timingSafeCompare (was fixed but duplicated)
- ChallengeTrigger.timingSafeCompare (STILL HAD the early-return timing leak — guard lhs.count == rhs.count else { return false } exposes length to attacker)

All three call sites now use the shared internal function which iterates max(lhs, rhs) times with modular indexing.

Also change timebaseInfo from static var to static let in:
- KernelHookSideChannel.swift
- TimingRatioBaseline.swift (value is set once at first access and never mutated)

https://claude.ai/code/session_01NU6joJXLub9mCmf39r5VAW