### PR TITLE
fix: umbrella header, thread probe leak, sysctl null-term, watchdog s…

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_emulator_detect.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_emulator_detect.c
@@ -156,8 +156,9 @@ static int probe_ostype(void) {
     xor_decode(expected_enc, sizeof(expected_enc), expected, 0x55u);
 
     char buf[64] = {0};
-    size_t bsz = sizeof(buf);
+    size_t bsz = sizeof(buf) - 1; /* leave room for defensive null-terminator */
     if (sysctlbyname(name, buf, &bsz, NULL, 0) != 0) return 0; /* query failed */
+    buf[sizeof(buf) - 1] = '\0'; /* ensure null-termination regardless of kernel output */
     return (strcmp(buf, expected) == 0) ? 1 : 0;
 }
 
@@ -171,7 +172,15 @@ static int probe_thread_count(void) {
     thread_act_array_t list = NULL;
     mach_msg_type_number_t cnt = 0;
     kern_return_t kr = task_threads(mach_task_self(), &list, &cnt);
-    if (kr != KERN_SUCCESS) return 1; /* error — treat as ok to avoid false positives */
+    if (kr != KERN_SUCCESS) {
+        /* Defensive cleanup: kernel may partially populate list on failure. */
+        if (list != NULL && cnt > 0) {
+            vm_deallocate(mach_task_self(),
+                          (vm_address_t)list,
+                          (vm_size_t)cnt * sizeof(thread_t));
+        }
+        return 1; /* error — treat as ok to avoid false positives */
+    }
     int n = (int)cnt;
     for (int i = 0; i < n; i++)
         mach_port_deallocate(mach_task_self(), list[i]);

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_sync_barrier.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_sync_barrier.c
@@ -122,10 +122,10 @@ int cprisk_vm_sync_barrier_step(cprisk_vm_sync_barrier_ctx_t *ctx,
         }
     } else {
         ctx->no_advance_count = 0u;
-        ctx->watchdog_stuck   = 0u;
-        /* Note: s_global_stuck is intentionally NOT cleared here.  On a real
-         * device the watchdog always advances; if it ever stopped advancing
-         * (stuck=1) then recovered, that itself is anomalous. */
+        /* Once stuck, stay stuck per-frame too — matches the global semantics.
+         * On a real device the watchdog never stalls long enough to trip the
+         * threshold; if it ever did then recovered, that itself is anomalous
+         * and should remain flagged for the lifetime of the frame. */
     }
 
     const uint32_t mix = sb_avalanche32(delta_wdog ^ pc ^ ctx->step_counter ^ 0xBAADF00Du);

--- a/RiskDetectorApp/Sources/CRiskCore/include/CRiskCore.h
+++ b/RiskDetectorApp/Sources/CRiskCore/include/CRiskCore.h
@@ -15,6 +15,8 @@
 #include "cprisk_vm_interpreter.h"
 #include "cprisk_crypto_trace.h"
 #include "cprisk_cff.h"
+#include "cprisk_emulator_detect.h"
+#include "cprisk_vm_sync_barrier.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
…tuck state

4 bugs found during code review of the latest security hardening commits:

1. CRITICAL — CRiskCore.h umbrella header missing emulator/barrier exports cprisk_emulator_detect.h and cprisk_vm_sync_barrier.h were not included in the umbrella header, making cprisk_emulator_probe(), cprisk_emulator_quick_probe(), cprisk_emulator_is_hostile() etc invisible to Swift.  All Swift call-sites (ReportEnvelope HKDF, HostileEnvironmentReporter) would fail to compile.

2. probe_thread_count() memory leak on error path When task_threads() returns KERN_FAILURE the kernel may have partially allocated the thread list.  Added defensive vm_deallocate on the error path to prevent a leak.

3. probe_ostype() defensive null-termination sysctl is expected to null-terminate, but defensively limit the read buffer to sizeof(buf)-1 and force buf[sizeof(buf)-1] = '\0' to prevent an unterminated strcmp if the kernel behaviour ever differs.

4. watchdog_stuck per-frame reset removed Previously, ctx->watchdog_stuck was cleared when the watchdog resumed advancing, but the process-global s_global_stuck was intentionally never cleared (once stuck = suspicious forever).  This asymmetry meant the per-frame and global states could diverge, causing inconsistent probe results.  Now per-frame stuck is also sticky — once set, never cleared.

https://claude.ai/code/session_01DaiinVxBUUMFkMKNtZeoC6