### PR TITLE
sec(vmp): complete 24/24 opcode variant pools + whitebox DCA hardening

### DIFF
--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_oph_table.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_oph_table.c
@@ -59,11 +59,11 @@ static cprisk_vm_flow_t cprisk_vm_dispatch_core_family_i(cprisk_vm_interp_frame_
          * defeat Capstone L1/L2 address-keyed disassembly caching. */
         return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x11u, cprisk_vm_oph_select_nop);
     case CPRISK_VM_OP_RET:
-        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x12u, cprisk_vm_oph_ret);
+        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x12u, cprisk_vm_oph_select_ret);
     case CPRISK_VM_OP_RAW_REGION:
-        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x13u, cprisk_vm_oph_raw_region);
+        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x13u, cprisk_vm_oph_select_raw_region);
     case CPRISK_VM_OP_HALT:
-        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x14u, cprisk_vm_oph_halt);
+        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x14u, cprisk_vm_oph_select_halt);
     default:
         return cprisk_vm_oph_unknown(fr, op_raw, logical, imm, pc, hvar);
     }
@@ -107,11 +107,11 @@ static cprisk_vm_flow_t cprisk_vm_dispatch_branch_family_i(cprisk_vm_interp_fram
     case CPRISK_VM_OP_BRANCH_REL:
         return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x31u, cprisk_vm_oph_select_branch_rel);
     case CPRISK_VM_OP_BRANCH_IND:
-        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x35u, cprisk_vm_oph_branch_ind);
+        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x35u, cprisk_vm_oph_select_branch_ind);
     case CPRISK_VM_OP_BRANCH_COND:
         return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x32u, cprisk_vm_oph_select_branch_cond);
     case CPRISK_VM_OP_CALL:
-        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x33u, cprisk_vm_oph_call);
+        return cprisk_vm_dispatch_leaf_i(fr, op_raw, logical, imm, pc, hvar, 0x33u, cprisk_vm_oph_select_call);
     default:
         return cprisk_vm_oph_unknown(fr, op_raw, logical, imm, pc, hvar);
     }

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_oph_variants.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_vm_oph_variants.c
@@ -1284,3 +1284,204 @@ cprisk_vm_flow_t cprisk_vm_oph_select_vreg_mem(cprisk_vm_interp_frame_t *fr,
     const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
     return variants[idx](fr, op_raw, logical, imm, pc, hvar);
 }
+
+/* ── RET variants ─────────────────────────────────────────────────────────── */
+
+/* v0: canonical */
+cprisk_vm_flow_t cprisk_vm_oph_ret_v0(cprisk_vm_interp_frame_t *fr,
+                                       uint8_t op_raw, uint8_t logical,
+                                       uint64_t imm, uint32_t pc, uint32_t hvar) {
+    return cprisk_vm_oph_ret(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v1: double-XOR identity on acc slot keyed from return-stack depth — net zero */
+cprisk_vm_flow_t cprisk_vm_oph_ret_v1(cprisk_vm_interp_frame_t *fr,
+                                       uint8_t op_raw, uint8_t logical,
+                                       uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint8_t  mask = (uint8_t)(fr->session_mix ^ (uint32_t)fr->return_sp ^ 0x52u);
+    const uint32_t slot = fr->return_sp & 3u;
+    fr->acc[slot] ^= mask;
+    fr->acc[slot] ^= mask;   /* net zero */
+    return cprisk_vm_oph_ret(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v2: add-subtract identity on opaque_chain — net zero */
+cprisk_vm_flow_t cprisk_vm_oph_ret_v2(cprisk_vm_interp_frame_t *fr,
+                                       uint8_t op_raw, uint8_t logical,
+                                       uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint32_t delta = vv_avalanche32((uint32_t)fr->func_id ^ hvar ^ 0x52455476u); /* "RETv" */
+    fr->opaque_chain += delta;
+    fr->opaque_chain -= delta;   /* net zero */
+    return cprisk_vm_oph_ret(fr, op_raw, logical, imm, pc, hvar);
+}
+
+cprisk_vm_flow_t cprisk_vm_oph_select_ret(cprisk_vm_interp_frame_t *fr,
+                                           uint8_t op_raw, uint8_t logical,
+                                           uint64_t imm, uint32_t pc, uint32_t hvar) {
+    static const cprisk_vm_oph_fn variants[CPRISK_VM_OPH_N_VARIANTS_LANE] = {
+        cprisk_vm_oph_ret_v0,
+        cprisk_vm_oph_ret_v1,
+        cprisk_vm_oph_ret_v2,
+    };
+    const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
+    return variants[idx](fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* ── HALT variants ────────────────────────────────────────────────────────── */
+
+/* v0: canonical */
+cprisk_vm_flow_t cprisk_vm_oph_halt_v0(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    return cprisk_vm_oph_halt(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v1: double-XOR identity on acc slot keyed from steps — net zero */
+cprisk_vm_flow_t cprisk_vm_oph_halt_v1(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint8_t  mask = (uint8_t)(fr->session_mix ^ (uint32_t)fr->steps ^ 0x48u); /* 'H' */
+    const uint32_t slot = (fr->steps + 1u) & 3u;
+    fr->acc[slot] ^= mask;
+    fr->acc[slot] ^= mask;   /* net zero */
+    return cprisk_vm_oph_halt(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v2: add-subtract identity on opaque_chain — net zero */
+cprisk_vm_flow_t cprisk_vm_oph_halt_v2(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint32_t delta = vv_avalanche32((uint32_t)(fr->func_id >> 16u) ^ hvar ^ 0x48414C54u); /* "HALT" */
+    fr->opaque_chain += delta;
+    fr->opaque_chain -= delta;   /* net zero */
+    return cprisk_vm_oph_halt(fr, op_raw, logical, imm, pc, hvar);
+}
+
+cprisk_vm_flow_t cprisk_vm_oph_select_halt(cprisk_vm_interp_frame_t *fr,
+                                            uint8_t op_raw, uint8_t logical,
+                                            uint64_t imm, uint32_t pc, uint32_t hvar) {
+    static const cprisk_vm_oph_fn variants[CPRISK_VM_OPH_N_VARIANTS_LANE] = {
+        cprisk_vm_oph_halt_v0,
+        cprisk_vm_oph_halt_v1,
+        cprisk_vm_oph_halt_v2,
+    };
+    const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
+    return variants[idx](fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* ── RAW_REGION variants ──────────────────────────────────────────────────── */
+
+/* v0: canonical */
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v0(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    return cprisk_vm_oph_raw_region(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v1: double-negate imm identity (−(−imm) == imm in two's complement) */
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v1(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t neg     = (~imm) + 1u;
+    const uint64_t imm_eff = (~neg) + 1u;
+    return cprisk_vm_oph_raw_region(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+/* v2: XOR-fold imm identity ((imm ^ key) ^ key == imm) */
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v2(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t key     = (uint64_t)fr->session_mix ^ ((uint64_t)fr->opaque_chain << 47u);
+    const uint64_t imm_eff = (imm ^ key) ^ key;
+    return cprisk_vm_oph_raw_region(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+cprisk_vm_flow_t cprisk_vm_oph_select_raw_region(cprisk_vm_interp_frame_t *fr,
+                                                  uint8_t op_raw, uint8_t logical,
+                                                  uint64_t imm, uint32_t pc, uint32_t hvar) {
+    static const cprisk_vm_oph_fn variants[CPRISK_VM_OPH_N_VARIANTS_LANE] = {
+        cprisk_vm_oph_raw_region_v0,
+        cprisk_vm_oph_raw_region_v1,
+        cprisk_vm_oph_raw_region_v2,
+    };
+    const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
+    return variants[idx](fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* ── BRANCH_IND variants ──────────────────────────────────────────────────── */
+
+/* v0: canonical */
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v0(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    return cprisk_vm_oph_branch_ind(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v1: double-negate imm identity */
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v1(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t neg     = (~imm) + 1u;
+    const uint64_t imm_eff = (~neg) + 1u;
+    return cprisk_vm_oph_branch_ind(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+/* v2: XOR-fold imm identity */
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v2(cprisk_vm_interp_frame_t *fr,
+                                              uint8_t op_raw, uint8_t logical,
+                                              uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t key     = (uint64_t)fr->session_mix ^ ((uint64_t)fr->opaque_chain << 53u);
+    const uint64_t imm_eff = (imm ^ key) ^ key;
+    return cprisk_vm_oph_branch_ind(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+cprisk_vm_flow_t cprisk_vm_oph_select_branch_ind(cprisk_vm_interp_frame_t *fr,
+                                                  uint8_t op_raw, uint8_t logical,
+                                                  uint64_t imm, uint32_t pc, uint32_t hvar) {
+    static const cprisk_vm_oph_fn variants[CPRISK_VM_OPH_N_VARIANTS_LANE] = {
+        cprisk_vm_oph_branch_ind_v0,
+        cprisk_vm_oph_branch_ind_v1,
+        cprisk_vm_oph_branch_ind_v2,
+    };
+    const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
+    return variants[idx](fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* ── CALL variants ────────────────────────────────────────────────────────── */
+
+/* v0: canonical */
+cprisk_vm_flow_t cprisk_vm_oph_call_v0(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    return cprisk_vm_oph_call(fr, op_raw, logical, imm, pc, hvar);
+}
+
+/* v1: double-negate imm identity */
+cprisk_vm_flow_t cprisk_vm_oph_call_v1(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t neg     = (~imm) + 1u;
+    const uint64_t imm_eff = (~neg) + 1u;
+    return cprisk_vm_oph_call(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+/* v2: XOR-fold imm identity */
+cprisk_vm_flow_t cprisk_vm_oph_call_v2(cprisk_vm_interp_frame_t *fr,
+                                        uint8_t op_raw, uint8_t logical,
+                                        uint64_t imm, uint32_t pc, uint32_t hvar) {
+    const uint64_t key     = (uint64_t)fr->session_mix ^ ((uint64_t)fr->opaque_chain << 59u);
+    const uint64_t imm_eff = (imm ^ key) ^ key;
+    return cprisk_vm_oph_call(fr, op_raw, logical, imm_eff, pc, hvar);
+}
+
+cprisk_vm_flow_t cprisk_vm_oph_select_call(cprisk_vm_interp_frame_t *fr,
+                                            uint8_t op_raw, uint8_t logical,
+                                            uint64_t imm, uint32_t pc, uint32_t hvar) {
+    static const cprisk_vm_oph_fn variants[CPRISK_VM_OPH_N_VARIANTS_LANE] = {
+        cprisk_vm_oph_call_v0,
+        cprisk_vm_oph_call_v1,
+        cprisk_vm_oph_call_v2,
+    };
+    const uint32_t idx = vv_select_index(fr, logical, CPRISK_VM_OPH_N_VARIANTS_LANE);
+    return variants[idx](fr, op_raw, logical, imm, pc, hvar);
+}

--- a/RiskDetectorApp/Sources/CRiskCore/cprisk_whitebox.c
+++ b/RiskDetectorApp/Sources/CRiskCore/cprisk_whitebox.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #ifdef __APPLE__
 #include <TargetConditionals.h>
+#include <mach/mach_time.h>
 #endif
 
 #include "include/cprisk_macho.h"
@@ -306,19 +307,68 @@ static uint8_t cprisk_rotl8_i(uint8_t value, unsigned int shift) {
     return (uint8_t)((value << shift) | (value >> (8U - shift)));
 }
 
+/*
+ * DCA countermeasure: per-evaluation Fisher-Yates shuffle over [0, STATE_SIZE).
+ *
+ * Each evaluation generates a random permutation of state-byte indices using a
+ * splitmix64 PRNG seeded from mach_absolute_time() XOR the first 8 input bytes.
+ * Mix layers process state bytes in permuted order (still writing to correct
+ * output slots — see correctness note in cprisk_whitebox_first_mix_layer_i).
+ *
+ * Effect: the table access order is different every evaluation.  First-order DCA
+ * that correlates "which table index is accessed at position j of the trace" with
+ * intermediate state values must now also recover the permutation, which is
+ * derived from a high-resolution timer value and therefore unknown to the attacker
+ * even when input and output are known.
+ */
+static void cprisk_whitebox_gen_shuffle_i(
+    uint8_t perm[CPRISK_WHITEBOX_STATE_SIZE],
+    const uint8_t input[CPRISK_WHITEBOX_STATE_SIZE]
+) {
+    uint64_t seed = mach_absolute_time();
+    /* Mix in first 8 bytes of input so same-time calls with different inputs diverge */
+    uint64_t in64;
+    memcpy(&in64, input, sizeof(in64));
+    seed ^= in64;
+    seed ^= 0x44434120484152Dull; /* "DCA HAR" */
+
+    for (size_t i = 0; i < CPRISK_WHITEBOX_STATE_SIZE; i++)
+        perm[i] = (uint8_t)i;
+
+    /* Fisher-Yates with splitmix64 */
+    for (size_t i = CPRISK_WHITEBOX_STATE_SIZE - 1u; i > 0u; i--) {
+        seed += 0x9E3779B97F4A7C15ULL;
+        uint64_t z = seed;
+        z = (z ^ (z >> 30u)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27u)) * 0x94D049BB133111EBULL;
+        z ^= z >> 31u;
+        const size_t j = (size_t)(z % (uint64_t)(i + 1u));
+        const uint8_t tmp = perm[i];
+        perm[i] = perm[j];
+        perm[j] = tmp;
+    }
+}
+
 static void cprisk_whitebox_first_mix_layer_i(
     const uint8_t *round_tables,
     const uint8_t *round_constants,
     const uint8_t state[CPRISK_WHITEBOX_STATE_SIZE],
     size_t round,
-    uint8_t out[CPRISK_WHITEBOX_STATE_SIZE]
+    uint8_t out[CPRISK_WHITEBOX_STATE_SIZE],
+    const uint8_t perm[CPRISK_WHITEBOX_STATE_SIZE]
 ) {
-    for (size_t i = 0; i < CPRISK_WHITEBOX_STATE_SIZE; i++) {
+    /*
+     * Correctness: state[] is read-only within this loop; out[] is indexed by i
+     * (= perm[j]).  Since no iteration reads from out[], processing bytes in
+     * permuted order yields identical results to sequential order.
+     */
+    for (size_t j = 0; j < CPRISK_WHITEBOX_STATE_SIZE; j++) {
+        const size_t i = perm[j];
         const uint8_t *table = round_tables + i * CPRISK_WHITEBOX_TABLE_WIDTH;
-        /* Dummy reads before real lookup — noise to confuse hexdump tracing */
+        /* Dummy reads before real lookup */
         cprisk_whitebox_dummy_reads_i(table, state[i], i, round);
         const uint8_t table_value = table[state[i]];
-        /* Dummy reads after — attacker sees real read sandwiched by noise */
+        /* Dummy reads after — real read sandwiched by noise */
         cprisk_whitebox_dummy_reads_i(table, table_value, i ^ 0x1Fu, round ^ 0x3u);
         const uint8_t mixed = (uint8_t)(table_value ^
                                         state[(i + 1u) % CPRISK_WHITEBOX_STATE_SIZE] ^
@@ -349,9 +399,11 @@ static void cprisk_whitebox_second_mix_layer_i(
     const uint8_t *round_constants,
     const uint8_t state[CPRISK_WHITEBOX_STATE_SIZE],
     size_t round,
-    uint8_t out[CPRISK_WHITEBOX_STATE_SIZE]
+    uint8_t out[CPRISK_WHITEBOX_STATE_SIZE],
+    const uint8_t perm[CPRISK_WHITEBOX_STATE_SIZE]
 ) {
-    for (size_t i = 0; i < CPRISK_WHITEBOX_STATE_SIZE; i++) {
+    for (size_t j = 0; j < CPRISK_WHITEBOX_STATE_SIZE; j++) {
+        const size_t i = perm[j];
         const uint8_t *table = round_tables + i * CPRISK_WHITEBOX_TABLE_WIDTH;
         cprisk_whitebox_dummy_reads_i(table, state[i], i ^ 0xAu, round + 4u);
         const uint8_t table_value = table[state[i]];
@@ -405,27 +457,23 @@ static inline void cprisk_whitebox_dummy_reads_i(
     size_t position,
     size_t round
 ) {
-    /* Derive two dummy indices from position + round + real_idx to ensure they
-     * are data-dependent (not constant-foldable) while being self-cancelling. */
+    /*
+     * Derive four dummy indices from position + round + real_idx.
+     * Four reads (vs the original two) give the real lookup a 1-in-5 share
+     * of the access trace instead of 1-in-3, raising the noise floor for
+     * first-order DCA correlation attacks that need to isolate the real read.
+     * All indices are data-dependent so they resist constant-folding.
+     */
     const uint8_t dummy_a = (uint8_t)((real_idx * 0x9Du) ^ (uint8_t)(position * 0x6Bu) ^ (uint8_t)(round * 0xA3u));
     const uint8_t dummy_b = (uint8_t)((real_idx ^ dummy_a) * 0xC3u ^ (uint8_t)(position + round));
+    const uint8_t dummy_c = (uint8_t)((dummy_a * 0x53u) ^ dummy_b ^ (uint8_t)(round * 0x7Fu));
+    const uint8_t dummy_d = (uint8_t)((dummy_b * 0x71u) ^ real_idx ^ (uint8_t)(position * 0xB1u));
 
-    /*
-     * Read both dummy entries and fold them into the sink. Previously the
-     * code XORed `ra ^ ra` (and `rb ^ rb`) which is the constant 0 — a
-     * reasonable optimizer eliminates the entire fold expression and the
-     * "sink" becomes a no-op even though `s_wb_dummy_sink` is volatile-ish.
-     * The two reads themselves still happen because of `volatile`-style
-     * access pattern on the table, but the tracer-visible *value* of the
-     * sink does not change, weakening the cover-trace.
-     *
-     * Use a real accumulation: sink XOR ra XOR rb. The values still depend
-     * on the table contents at attacker-unguessable indices, so the sink
-     * mutates with every cover read, but they don't leak the real lookup.
-     */
     const uint8_t ra = table[dummy_a];
     const uint8_t rb = table[dummy_b];
-    s_wb_dummy_sink = (uint8_t)(s_wb_dummy_sink ^ ra ^ rb);
+    const uint8_t rc = table[dummy_c];
+    const uint8_t rd = table[dummy_d];
+    s_wb_dummy_sink = (uint8_t)(s_wb_dummy_sink ^ ra ^ rb ^ rc ^ rd);
 }
 
 static int cprisk_ct_mem_diff_i(const uint8_t *lhs, const uint8_t *rhs, size_t len) {
@@ -909,9 +957,14 @@ static int cprisk_whitebox_eval_record_i(
     uint8_t state[CPRISK_WHITEBOX_STATE_SIZE];
     uint8_t next[CPRISK_WHITEBOX_STATE_SIZE];
     uint8_t scratch[CPRISK_WHITEBOX_STATE_SIZE];
+    uint8_t dca_perm[CPRISK_WHITEBOX_STATE_SIZE];
     const int enhanced_diffusion =
         (bundle->header.flags & CPRISK_ARMOR_WHITEBOX_FLAG_ENHANCED_DIFFUSION) != 0u;
     memcpy(state, input, sizeof(state));
+
+    /* Generate one per-evaluation shuffle; reused across all rounds so the
+     * permutation is stable within a call but random between calls. */
+    cprisk_whitebox_gen_shuffle_i(dca_perm, input);
 
     for (size_t round = 0; round < CPRISK_WHITEBOX_ROUND_COUNT; round++) {
         const uint8_t *round_tables = NULL;
@@ -936,7 +989,7 @@ static int cprisk_whitebox_eval_record_i(
         const uint8_t *round_constants =
             record->round_constants + round * CPRISK_WHITEBOX_STATE_SIZE;
 
-        cprisk_whitebox_first_mix_layer_i(round_tables, round_constants, state, round, next);
+        cprisk_whitebox_first_mix_layer_i(round_tables, round_constants, state, round, next, dca_perm);
         if (enhanced_diffusion) {
             cprisk_whitebox_strong_mix_layer_i(next, round_constants, scratch);
             cprisk_whitebox_second_mix_layer_i(
@@ -944,7 +997,8 @@ static int cprisk_whitebox_eval_record_i(
                 round_constants,
                 scratch,
                 round,
-                next
+                next,
+                dca_perm
             );
         }
 
@@ -965,6 +1019,7 @@ static int cprisk_whitebox_eval_record_i(
     cprisk_secure_zero(state, sizeof(state));
     cprisk_secure_zero(next, sizeof(next));
     cprisk_secure_zero(scratch, sizeof(scratch));
+    cprisk_secure_zero(dca_perm, sizeof(dca_perm));
     return 0;
 }
 

--- a/RiskDetectorApp/Sources/CRiskCore/include/cprisk_vm_oph_variants.h
+++ b/RiskDetectorApp/Sources/CRiskCore/include/cprisk_vm_oph_variants.h
@@ -106,6 +106,32 @@ cprisk_vm_flow_t cprisk_vm_oph_vreg_mem_v1      (cprisk_vm_interp_frame_t *fr, u
 cprisk_vm_flow_t cprisk_vm_oph_vreg_mem_v2      (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
 cprisk_vm_flow_t cprisk_vm_oph_select_vreg_mem  (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
 
+/* Control-flow / terminal opcode variant pools (no-imm: NOP-pattern; with-imm: identity-transform delegate). */
+cprisk_vm_flow_t cprisk_vm_oph_ret_v0           (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_ret_v1           (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_ret_v2           (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_select_ret       (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+
+cprisk_vm_flow_t cprisk_vm_oph_halt_v0          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_halt_v1          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_halt_v2          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_select_halt      (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v0    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v1    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_raw_region_v2    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_select_raw_region(cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v0    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v1    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_branch_ind_v2    (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_select_branch_ind(cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+
+cprisk_vm_flow_t cprisk_vm_oph_call_v0          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_call_v1          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_call_v2          (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+cprisk_vm_flow_t cprisk_vm_oph_select_call      (cprisk_vm_interp_frame_t *fr, uint8_t op_raw, uint8_t logical, uint64_t imm, uint32_t pc, uint32_t hvar);
+
 #ifdef __cplusplus
 }
 #endif

--- a/RiskDetectorApp/vmp_policy.yaml
+++ b/RiskDetectorApp/vmp_policy.yaml
@@ -46,6 +46,10 @@ functions:
     - cprisk_frida_runtime_snapshot
     - GumTrampolineDetector.detect
     - FridaMemoryLayoutDetector.detect
+    # v7.6 additions: anti-bypass detector + whitebox PRF entry + dead-handler touch
+    - RandomizedDetection.detect
+    - cprisk_whitebox_evaluate_domain
+    - cprisk_vm_dead_touch_i
   partial:
     - AnomalyDetector.detectRiskScoreAnomaly
     - ReportEnvelope.buildSignatureInput
@@ -60,6 +64,10 @@ functions:
     - AntiTamperingSignalProvider.signals
     - CPRiskKit.evaluate
     - UnixSocketSweepDetector.detect
+    # v7.6 additions: watchdog provider + jailbreak + device fingerprint
+    - AntiDebugWatchdogProvider.signals
+    - JailbreakSignalProvider.signals
+    - DeviceFingerprintProvider.signals
   never:
     - direct_syscall.cprisk_direct_syscall0
     - direct_syscall.cprisk_direct_syscall6


### PR DESCRIPTION
Variant pools (5 remaining opcodes → all 24 now have 3-body pools):
- RET/HALT (no-imm): v1=double-XOR on acc slot, v2=add-subtract on opaque_chain
- RAW_REGION/BRANCH_IND/CALL (imm-bearing): v1=double-negate, v2=XOR-fold with distinct key shifts (47u/53u/59u) per opcode
- Wired all 5 into cprisk_vm_oph_table.c via select_* dispatchers

Whitebox PRF anti-DCA hardening (cprisk_whitebox.c):
- cprisk_whitebox_gen_shuffle_i: Fisher-Yates permutation of [0..31] seeded from mach_absolute_time() XOR first 8 bytes of input; generated once per evaluation, shared across rounds — O(N) cost per call
- first/second_mix_layer_i: process state bytes in permuted order; correctness preserved because state[] is read-only within each layer, output indexed by i (= perm[j]), so every slot written exactly once
- dummy_reads_i: expanded from 2 to 4 reads per real lookup (dummy_c, dummy_d derived from dummy_a/b); real read now ~1/5 of trace volume vs 1/3 before

VMProtector policy (vmp_policy.yaml) — v7.6 additions:
- full: RandomizedDetection.detect, cprisk_whitebox_evaluate_domain, cprisk_vm_dead_touch_i
- partial: AntiDebugWatchdogProvider.signals, JailbreakSignalProvider.signals, DeviceFingerprintProvider.signals

https://claude.ai/code/session_013sUSEpEaBZ3TP9nLs7Xe2c