### PR TITLE
feat(detection): add RootHide jailbreak detection support

### DIFF
--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DylibInjectionDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/DylibInjectionDetector.swift
@@ -33,6 +33,7 @@ struct DylibInjectionDetector: Detector {
         "/var/LIB/",
         "/var/ulb/",
         "/usr/lib/tweaks/",
+        "/bootstrap/",
     ]
 
     /// System / legitimate path prefixes that are expected on a stock device.

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/ModuleWhitelistDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Detection/AntiTampering/ModuleWhitelistDetector.swift
@@ -26,7 +26,11 @@ struct ModuleWhitelistDetector: Detector {
         "/private/var/containers/",       // App sandbox — own bundle allowed
         "/developer/",                     // Developer disk (already flagged by other detector)
         "/var/staged_system_apps/",        // OTA updates staging
-        "/private/preboot/",               // Preboot volume
+    ]
+
+    private static let prebootSystemSubpaths: [String] = [
+        "/cryptexes/",
+        "/system/",
     ]
 
     /// Additional rootless jailbreak paths that are already covered by DylibInjectionDetector
@@ -37,6 +41,10 @@ struct ModuleWhitelistDetector: Detector {
         "/var/ulb/",
         "/usr/lib/tweaks/",
         "/bootstrap/",
+    ]
+
+    private static let roothideSuspiciousKeywords: [String] = [
+        "roothide", "procursus", "ellekit",
     ]
 
     /// File extensions that must appear in any legitimate framework or dylib name.
@@ -82,6 +90,21 @@ struct ModuleWhitelistDetector: Detector {
 
             // Skip the app's own bundle
             if lowerPath.hasPrefix(appBundlePath) {
+                continue
+            }
+
+            // Preboot volume: allow known system subpaths, flag everything else
+            if lowerPath.hasPrefix("/private/preboot/") {
+                let isSystemPreboot = Self.prebootSystemSubpaths.contains(where: { sub in
+                    lowerPath.contains(sub)
+                })
+                if isSystemPreboot {
+                    continue
+                }
+                let hasRoothideKeyword = Self.roothideSuspiciousKeywords.contains(where: { lowerPath.contains($0) })
+                let roothideBonus: Double = hasRoothideKeyword ? 8 : 0
+                score += Self.scoreJailbreakPath + roothideBonus
+                methods.append("mwl:preboot_nonstandard\(hasRoothideKeyword ? "_roothide" : ""):\(sanitizeName(imagePath))")
                 continue
             }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/FileDetector.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Jailbreak/Detectors/FileDetector.swift
@@ -175,6 +175,14 @@ struct FileDetector: Detector {
             Logger.log("jailbreak.file.hit: preboot_jb (+20)")
         }
 
+        let roothideResult = detectRootHideBootstrap()
+        score += roothideResult.score
+        methods.append(contentsOf: roothideResult.methods)
+
+        let roothideEnvResult = detectRootHideEnvVars()
+        score += roothideEnvResult.score
+        methods.append(contentsOf: roothideEnvResult.methods)
+
         return DetectorResult(score: score, methods: methods)
 #endif
     }
@@ -257,10 +265,8 @@ struct FileDetector: Detector {
 
     private func hasPrebootJBDirectory() -> Bool {
 #if targetEnvironment(simulator)
-        // Simulator doesn't have the same preboot filesystem layout as real devices.
         return false
 #else
-        // Rootless jailbreaks often have /private/preboot/<UUID>/jb
         let root = "/private/preboot"
         guard DualPathValidator.validateFileStat(path: root).exists else { return false }
         guard let dir = opendir(root) else { return false }
@@ -282,6 +288,111 @@ struct FileDetector: Detector {
             scanned += 1
         }
         return false
+#endif
+    }
+
+    private func detectRootHideBootstrap() -> DetectorResult {
+#if targetEnvironment(simulator)
+        return .empty
+#else
+        var score: Double = 0
+        var methods: [String] = []
+
+        let root = "/private/preboot"
+        guard DualPathValidator.validateFileStat(path: root).exists else {
+            return DetectorResult(score: score, methods: methods)
+        }
+        guard let dir = opendir(root) else {
+            return DetectorResult(score: score, methods: methods)
+        }
+        defer { closedir(dir) }
+
+        let bootstrapMarkers = ["usr", "Library", "bin", "etc", "var"]
+
+        var scanned = 0
+        while scanned < 10, let entry = readdir(dir) {
+            var nameBuf = entry.pointee.d_name
+            let name = withUnsafePointer(to: &nameBuf.0) { ptr in
+                let len = strnlen(ptr, Int(MAXPATHLEN))
+                return (String(data: Data(bytes: ptr, count: len), encoding: .utf8) ?? "")
+            }
+            guard name != "." && name != ".." else { continue }
+
+            let uuidDir = "\(root)/\(name)"
+            guard isDirectoryPath(uuidDir) else {
+                scanned += 1
+                continue
+            }
+            guard let subDir = opendir(uuidDir) else {
+                scanned += 1
+                continue
+            }
+            defer { closedir(subDir) }
+
+            var subScanned = 0
+            while subScanned < 20, let subEntry = readdir(subDir) {
+                var subNameBuf = subEntry.pointee.d_name
+                let subName = withUnsafePointer(to: &subNameBuf.0) { ptr in
+                    let len = strnlen(ptr, Int(MAXPATHLEN))
+                    return (String(data: Data(bytes: ptr, count: len), encoding: .utf8) ?? "")
+                }
+                guard subName != "." && subName != ".." else { continue }
+
+                let candidateBase = "\(uuidDir)/\(subName)"
+                guard isDirectoryPath(candidateBase) else {
+                    subScanned += 1
+                    continue
+                }
+
+                if subName == "jb" { subScanned += 1; continue }
+
+                let lowerSub = subName.lowercased()
+                if lowerSub.contains("procursus") || lowerSub.contains("roothide") {
+                    score += 30
+                    methods.append("roothide:preboot_bootstrap:\(subName)")
+                    Logger.log("jailbreak.file.hit: roothide preboot bootstrap \(subName) (+30)")
+                    return DetectorResult(score: score, methods: methods)
+                }
+
+                var markerHits = 0
+                for marker in bootstrapMarkers {
+                    let markerPath = "\(candidateBase)/\(marker)"
+                    if isDirectoryPath(markerPath) {
+                        markerHits += 1
+                    }
+                }
+                if markerHits >= 3 {
+                    score += 25
+                    methods.append("roothide:preboot_hidden_bootstrap:\(subName)")
+                    Logger.log("jailbreak.file.hit: roothide hidden bootstrap structure \(subName) markers=\(markerHits) (+25)")
+                    return DetectorResult(score: score, methods: methods)
+                }
+
+                subScanned += 1
+            }
+            scanned += 1
+        }
+
+        return DetectorResult(score: score, methods: methods)
+#endif
+    }
+
+    private func detectRootHideEnvVars() -> DetectorResult {
+#if targetEnvironment(simulator)
+        return .empty
+#else
+        var score: Double = 0
+        var methods: [String] = []
+
+        for item in ObfuscatedConstants.roothideEnvVars {
+            if let val = getenv(item.name), strlen(val) > 0 {
+                score += item.score
+                methods.append("roothide:env:\(item.name)")
+                Logger.log("jailbreak.file.hit: roothide env \(item.name) (+\(item.score))")
+            }
+        }
+
+        return DetectorResult(score: score, methods: methods)
 #endif
     }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/ObfuscatedJailbreakStrings.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/ObfuscatedJailbreakStrings.swift
@@ -34,6 +34,10 @@ extension ObfuscatedConstants {
             (b64("L3Vzci9zYmluL3NzaGQ="), 15),
             (b64("L3Vzci9iaW4vc3No"), 10),
             (b64("L2Jpbi9iYXNo"), 10),
+            (b64("L3Zhci9tb2JpbGUvLnJvb3RoaWRl"), 30),
+            (b64("L3Zhci9tb2JpbGUvLmluc3RhbGxlZF9yb290aGlkZQ=="), 30),
+            (b64("L3Zhci9tb2JpbGUvLnByb2N1cnN1c19zdHJhcHBlZA=="), 25),
+            (b64("L3Zhci9qYi8ucHJvY3Vyc3VzX3N0cmFwcGVk"), 25),
         ]
     }
 
@@ -44,6 +48,7 @@ extension ObfuscatedConstants {
             b64("L3Zhci9qYg=="),
             b64("L3Vzci9saWIvRWxsZUtpdC5keWxpYg=="),
             b64("L0xpYnJhcnkvTW9iaWxlU3Vic3RyYXRlL01vYmlsZVN1YnN0cmF0ZS5keWxpYg=="),
+            b64("L3Zhci9tb2JpbGUvLnJvb3RoaWRl"),
         ]
     }
 
@@ -73,6 +78,8 @@ extension ObfuscatedConstants {
             b64("ZWxsZWtpdA=="),
             b64("YXB0"),
             b64("ZHBrZw=="),
+            b64("cm9vdGhpZGVpbml0"),
+            b64("cm9vdGhpZGVwYXRjaGVy"),
         ]
     }
 
@@ -98,6 +105,14 @@ extension ObfuscatedConstants {
             b64("dGF1cmluZQ=="),
             b64("dW5jMHZlcg=="),
             b64("Y2hpbWVyYQ=="),
+        ]
+    }
+
+    static var roothideEnvVars: [(name: String, score: Double)] {
+        [
+            (b64("SkJST09U"), 40),
+            (b64("SkJfUk9PVF9QQVRI"), 40),
+            (b64("SkJSQU5E"), 35),
         ]
     }
 

--- a/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/ObfuscatedStrings.swift
+++ b/RiskDetectorApp/Sources/CloudPhoneRiskKit/Util/ObfuscatedStrings.swift
@@ -1057,6 +1057,7 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("dHdlYWs="),
             StringDeobfuscator.base64Decode("eHBvc2Vk"),
             keywordHook,
+            StringDeobfuscator.base64Decode("cm9vdGhpZGU="),
         ]
     }
 
@@ -1071,6 +1072,7 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("ZWxsZWtpdA=="),
             StringDeobfuscator.base64Decode("dHdlYWs="),
             keywordHook,
+            StringDeobfuscator.base64Decode("cm9vdGhpZGU="),
         ]
     }
 
@@ -1091,6 +1093,7 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("ZWxsZWtpdA=="),
             StringDeobfuscator.base64Decode("c2hhZG93"),
             StringDeobfuscator.base64Decode("ZG9wYW1pbmU="),
+            StringDeobfuscator.base64Decode("cm9vdGhpZGU="),
         ]
     }
 
@@ -1146,6 +1149,10 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("Q1BEaXN0cmlidXRlZE1lc3NhZ2luZw=="),
             StringDeobfuscator.base64Decode("SEJQcmVmZXJlbmNlcw=="),
             StringDeobfuscator.base64Decode("SEJMT3B0aW9uc0NvbnRyb2xsZXI="),
+            StringDeobfuscator.base64Decode("Um9vdEhpZGVNYW5hZ2Vy"),
+            StringDeobfuscator.base64Decode("Um9vdEhpZGVQYXRjaGVy"),
+            StringDeobfuscator.base64Decode("Um9vdEhpZGVBUEk="),
+            StringDeobfuscator.base64Decode("bGliUm9vdEhpZGVy"),
         ]
     }
 
@@ -1207,6 +1214,8 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("dHdlYWtpbmplY3Q="),
             StringDeobfuscator.base64Decode("c2hhZG93"),
             StringDeobfuscator.base64Decode("ZG9wYW1pbmU="),
+            StringDeobfuscator.base64Decode("cm9vdGhpZGU="),
+            StringDeobfuscator.base64Decode("bGliUm9vdEhpZGU="),
         ]
     }
 
@@ -1249,6 +1258,9 @@ enum ObfuscatedConstants {
             StringDeobfuscator.base64Decode("ZmxleA=="),
             StringDeobfuscator.base64Decode("cmV2ZWFsZGVidWc="),
             StringDeobfuscator.base64Decode("Y3ljcmlwdA=="),
+            StringDeobfuscator.base64Decode("cm9vdGhpZGU="),
+            StringDeobfuscator.base64Decode("cm9vdGhpZGVy"),
+            StringDeobfuscator.base64Decode("cHJvY3Vyc3Vz"),
         ]
     }
 


### PR DESCRIPTION
RootHide evades traditional jailbreak detection by randomizing bootstrap paths under /private/preboot/ instead of using standard /var/jb/. This adds multi-layer detection covering file paths, environment variables, dylib keywords, ObjC classes, and preboot bootstrap structure heuristics.

Key changes:
- FileDetector: scan preboot for hidden bootstrap structures (usr/Library/bin marker heuristic) and detect RootHide-specific env vars (JBROOT, JBRAND)
- ModuleWhitelistDetector: refine /private/preboot/ from blanket whitelist to targeted system-subpath whitelist, flagging non-system preboot dylibs
- DylibInjectionDetector: add /bootstrap/ prefix and roothide/procursus keywords
- ObfuscatedStrings: add roothide/libRootHide tokens to 6 detection lists (dylib keywords, image tokens, ObjC classes, scan patterns, dyld tokens)
- ObfuscatedJailbreakStrings: add roothide marker paths, env vars, process names

https://claude.ai/code/session_013oRUaMu8oEdRYL5gvDSTHD